### PR TITLE
Add SetView, README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,41 +3,122 @@
 [![Build](https://github.com/ionite34/einspect/actions/workflows/build.yml/badge.svg)](https://github.com/ionite34/einspect/actions/workflows/build.yml)
 [![codecov](https://codecov.io/gh/ionite34/einspect/branch/main/graph/badge.svg?token=v71SdG5Bo6)](https://codecov.io/gh/ionite34/einspect)
 
-Extended Inspect for CPython
+[![PyPI](https://img.shields.io/pypi/v/einspect)][pypi]
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/einspect)][pypi]
 
-Provides simple and robust ways to view and modify the base memory structures of Python objects at runtime.
+[pypi]: https://pypi.org/project/einspect/
 
-Note: The below examples show interactions with a `TupleView`, but applies much the same way generically for
-many of the specialized `View` subtypes that are dynamically returned by the `view` function. If no specific
-view is implemented, the base `View` will be used which represents limited interactions on the assumption of
-`PyObject` struct parts.
+> Extended Inspections for CPython
 
+### [Documentation](https://ionite.io/einspect)
+
+- View and modify memory structures of runtime objects.
+- Fully typed, extensible framework in pure Python.
+
+### Check detailed states of built-in objects
+```python
+from einspect import view
+
+ls = [1, 2, 3]
+v = view(ls)
+print(v.info())
+```
+```python
+PyListObject(at 0x2833738):
+   ob_refcnt: Py_ssize_t = 5
+   ob_type: *PyTypeObject = &[list]
+   ob_item: **PyObject = &[&[1], &[2], &[3], &[NULL]]
+   allocated: Py_ssize_t = 4
+```
+
+### Mutate tuples, strings, ints, or other immutable types
+```python
+from einspect import view
+
+t = ("A", "B")
+view(t)[1] = 10
+print(t)
+```
+```python
+("A", 10)
+```
 
 ```python
 from einspect import view
 
-print(view((1, 2)))
-print(view([1, 2]))
+a = "hello"
+b = 100
+
+view(a).buffer[:] = b"world"
+view(b).value = 5
+
+print("hello", 100)
+```
+```python
+world 5
+```
+
+### Move objects in memory
+```python
+from einspect import view
+
+s = "meaning of life"
+
+v = view(s)
+with v.unsafe():
+    v <<= 42
+
+print("meaning of life")
+print("meaning of life" == 42)
+```
+```python
+42
+True
+```
+
+## Table of Contents
+- [Views](#views)
+  - [Using the `einspect.view` constructor](#using-the-einspectview-constructor)
+  - [Inspecting struct attributes](#inspecting-struct-attributes)
+
+## Views
+
+### Using the `einspect.view` constructor
+
+This is the recommended and simplest way to create a `View` onto an object. Equivalent to constructing a specific `View` subtype from `einspect.views`, except the choice of subtype is automatic based on object type.
+
+```python
+from einspect import view
+
+print(view(1))
 print(view("hello"))
-print(view(256))
-print(view(object()))
+print(view([1, 2]))
+print(view((1, 2)))
 ```
 > ```
-> TupleView[tuple](<PyTupleObject at 0x100f19a00>)
-> ListView[list](<PyListObject at 0x10124f800>)
-> StrView[str](<PyUnicodeObject at 0x100f12ab0>)
-> IntView[int](<PyLongObject at 0x102058920>)
-> View[object](<PyObject at 0x100ea08a0>)
+> IntView(<PyLongObject at 0x102058920>)
+> StrView(<PyUnicodeObject at 0x100f12ab0>)
+> ListView(<PyListObject at 0x10124f800>)
+> TupleView(<PyTupleObject at 0x100f19a00>)
 > ```
 
-## 1. Viewing python object struct attributes
+### Inspecting struct attributes
 
-State information of the underlying `PyTupleObject` struct can be accessed through the view's attributes.
+Attributes of the underlying C Struct of objects can be accessed through the view's properties.
 ```python
+from einspect import view
+
+ls = [1, 2]
+v = view(ls)
+
+# Inherited from PyObject
 print(v.ref_count)  # ob_refcnt
 print(v.type)       # ob_type
+# Inherited from PyVarObject
 print(v.size)       # ob_size
-print(v.items)      # ob_item
+# From PyListObject
+print(v.item)       # ob_item
+print(v.allocated)  # allocated
 ```
 > ```
 > 4

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ print("meaning of life" == 42)
 True
 ```
 
+### Fully typed interface
+<img width="551" alt="image" src="https://user-images.githubusercontent.com/13956642/211129165-38a1c405-9d54-413c-962e-6917f1f3c2a1.png">
+
 ## Table of Contents
 - [Views](#views)
   - [Using the `einspect.view` constructor](#using-the-einspectview-constructor)

--- a/src/einspect/compat.py
+++ b/src/einspect/compat.py
@@ -8,10 +8,10 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Generic, NoReturn, TypeVar
 
+__all__ = ("Version", "RequiresPythonVersion", "python_req", "abc")
+
 if sys.version_info > (3, 8):
     abc = typing
-
-__all__ = ("Version", "RequiresPythonVersion", "python_req", "abc")
 
 
 class Version(Enum):

--- a/src/einspect/protocols/type_parse.py
+++ b/src/einspect/protocols/type_parse.py
@@ -43,19 +43,11 @@ aliases = {
 # ctypes generics to replace
 RE_PY_OBJECT = re.compile(r"^(py_object)(\[(.*)])$")
 RE_POINTER = re.compile(r"^(pointer)(\[(.*)])$")
-RE_ARRAY = re.compile(r"^(Array)(\[(.*)])$")
 
 
 def fix_ctypes_generics(type_hints: [str, str]) -> None:
     for name, hint in type_hints.items():
         if isinstance(hint, str):
-            # For python < 3.9, discard Array generic
-            if sys.version_info < (3, 9):
-                m_arr = RE_ARRAY.match(hint)
-                if m_arr:
-                    base = hint.replace(m_arr.group(2), "")
-                    type_hints[name] = base
-                    continue
             # Keep py_object and discard subscript
             m_pyobj = RE_PY_OBJECT.match(hint)
             log.debug("Source: %r Match: %r", hint, m_pyobj)

--- a/src/einspect/structs/deco.py
+++ b/src/einspect/structs/deco.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from ctypes import Structure
 from functools import partial
-from typing import Callable, Type, TypeVar, overload, Union, Sequence
+from typing import Callable, Type, TypeVar, overload, Union, Sequence, Tuple
 
 # noinspection PyUnresolvedReferences, PyProtectedMember
 from typing_extensions import _AnnotatedAlias, get_type_hints, get_args
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 
 _T = TypeVar("_T", bound=Type[Structure])
 
-FieldsType = Sequence[Union[tuple[str, type], tuple[str, type, int]]]
+FieldsType = Sequence[Union[Tuple[str, type], Tuple[str, type, int]]]
 
 _TYPE_REPLACED = object()
 
@@ -24,6 +24,7 @@ def struct(cls: _T, fields: None = None) -> _T:
     ...
 
 
+# noinspection PyDefaultArgument
 @overload
 def struct(*args, fields: FieldsType = []) -> Callable[[_T], _T]:
     ...

--- a/src/einspect/structs/deco.py
+++ b/src/einspect/structs/deco.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import logging
 from ctypes import Structure
-from typing import Callable, Type, TypeVar
+from functools import partial
+from typing import Callable, Type, TypeVar, overload, Union, Sequence
 
 # noinspection PyUnresolvedReferences, PyProtectedMember
 from typing_extensions import _AnnotatedAlias, get_type_hints, get_args
@@ -13,9 +14,42 @@ log = logging.getLogger(__name__)
 
 _T = TypeVar("_T", bound=Type[Structure])
 
+FieldsType = Sequence[Union[tuple[str, type], tuple[str, type, int]]]
 
-def struct(cls: _T) -> _T:
+_TYPE_REPLACED = object()
+
+
+@overload
+def struct(cls: _T, fields: None = None) -> _T:
+    ...
+
+
+@overload
+def struct(*args, fields: FieldsType = []) -> Callable[[_T], _T]:
+    ...
+
+
+def struct(cls=None, fields=None):
     """Decorator to declare _fields_ on Structures via type hints."""
+    # Normal decorator usage
+    if cls is not None:
+        return _struct(cls)
+
+    # Usage as a decorator factory
+    return partial(_struct, __fields=fields)
+
+
+def _struct(cls: _T, __fields: FieldsType | None = None) -> _T:
+    """Decorator to declare _fields_ on Structures via type hints."""
+    # if fields provided, replace type hints with temp sentinel
+    fields_overrides = {
+        tup[0]: tup for tup in __fields or ()
+    }
+    if __fields is not None:
+        for tup in __fields:
+            # This is to prevent errors during get_type_hints if there is an override
+            cls.__annotations__[tup[0]] = None
+
     fields = []
     try:
         hints = get_type_hints(cls, include_extras=True)
@@ -25,6 +59,10 @@ def struct(cls: _T) -> _T:
         hints = get_type_hints(cls, include_extras=True)
 
     for name, type_hint in hints.items():
+        # Use override if exists
+        if f := fields_overrides.get(name):
+            fields.append(f)
+            continue
         # Skip actual values like _fields_
         if name.startswith("_") and name.endswith("_"):
             continue

--- a/src/einspect/structs/py_list.py
+++ b/src/einspect/structs/py_list.py
@@ -5,6 +5,7 @@ from typing import TypeVar, List
 
 from typing_extensions import Annotated
 
+from einspect.types import ptr
 from einspect.protocols.delayed_bind import bind_api
 from einspect.structs.deco import struct
 from einspect.structs.py_object import PyObject, PyVarObject
@@ -21,14 +22,12 @@ class PyListObject(PyVarObject[list, None, _VT]):
     https://github.com/python/cpython/blob/3.11/Include/cpython/listobject.h
     """
 
-    _ob_item: POINTER(c_void_p)
+    ob_item: ptr[ptr[PyObject[_VT, None, None]]]
     allocated: Annotated[int, c_long]
 
-    @property
-    def ob_item(self) -> pointer[Array[pointer[PyObject[_VT, None, None]]]]:
-        arr_type = POINTER(PyObject) * self.allocated
-        # Cast _ob_item to a py_object array
-        return cast(self._ob_item, POINTER(arr_type))
+    @classmethod
+    def from_object(cls, obj: List[_VT]) -> PyListObject[_VT]:
+        return cls.from_address(id(obj))
 
     @classmethod
     def _format_fields_(cls) -> dict[str, str]:

--- a/src/einspect/structs/py_set.py
+++ b/src/einspect/structs/py_set.py
@@ -21,7 +21,9 @@ class SetEntry(Structure, Generic[_T]):
     hash: Annotated[int, Py_hash_t]
 
 
-@struct
+@struct(fields=[
+    ("smalltable", SetEntry * PySet_MINSIZE),
+])
 class PySetObject(PyObject[set, None, _T]):
     """
     Defines a PySetObject Structure.
@@ -35,7 +37,7 @@ class PySetObject(PyObject[set, None, _T]):
     table: ptr[SetEntry[_T]]
     hash: Annotated[int, Py_hash_t]
     finger: int
-    smalltable: Annotated[Array[SetEntry[_T]], SetEntry * PySet_MINSIZE]
+    smalltable: Array[SetEntry[_T]]
     weakreflist: ptr[PyObject]
 
     @classmethod

--- a/src/einspect/structs/py_set.py
+++ b/src/einspect/structs/py_set.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from ctypes import Structure, POINTER
 
+from typing_extensions import Annotated
+
 from einspect.api import Py_hash_t
 from einspect.structs.deco import struct
 from einspect.structs.py_object import PyObject
@@ -14,7 +16,7 @@ PySet_MINSIZE = 8
 @struct
 class SetEntry(Structure):
     key: POINTER(PyObject)
-    hash: Py_hash_t
+    hash: Annotated[int, Py_hash_t]
 
 
 @struct
@@ -29,7 +31,7 @@ class PySetObject(PyObject):
     used: int
     mask: int
     table: POINTER(SetEntry)
-    hash: Py_hash_t
+    hash: Annotated[int, Py_hash_t]
     finger: int
     smalltable: SetEntry * PySet_MINSIZE
     weakreflist: POINTER(PyObject)

--- a/src/einspect/structs/py_set.py
+++ b/src/einspect/structs/py_set.py
@@ -1,38 +1,44 @@
 from __future__ import annotations
 
-from ctypes import Structure, POINTER
+from ctypes import Structure, POINTER, pointer, Array
+from typing import TypeVar, Generic
 
 from typing_extensions import Annotated
 
+from einspect.types import ptr
 from einspect.api import Py_hash_t
 from einspect.structs.deco import struct
 from einspect.structs.py_object import PyObject
 
-
+_T = TypeVar("_T")
 PySet_MINSIZE = 8
 """https://github.com/python/cpython/blob/3.11/Include/cpython/setobject.h#L18"""
 
 
 @struct
-class SetEntry(Structure):
-    key: POINTER(PyObject)
+class SetEntry(Structure, Generic[_T]):
+    key: pointer[PyObject[_T, None, None]]
     hash: Annotated[int, Py_hash_t]
 
 
 @struct
-class PySetObject(PyObject):
+class PySetObject(PyObject[set, None, _T]):
     """
     Defines a PySetObject Structure.
 
     https://github.com/python/cpython/blob/3.11/Include/cpython/setobject.h#L36-L59
     """
 
-    fill: int
-    used: int
-    mask: int
-    table: POINTER(SetEntry)
+    fill: int  # Number active and dummy entries
+    used: int  # Number active entries
+    mask: int  # The table contains mask + 1 slots
+    table: ptr[SetEntry[_T]]
     hash: Annotated[int, Py_hash_t]
     finger: int
-    smalltable: SetEntry * PySet_MINSIZE
-    weakreflist: POINTER(PyObject)
+    smalltable: Annotated[Array[SetEntry[_T]], SetEntry * PySet_MINSIZE]
+    weakreflist: ptr[PyObject]
+
+    @classmethod
+    def from_object(cls, obj: set[_T]) -> PySetObject[_T]:
+        return cls.from_address(id(obj))
 

--- a/src/einspect/types.py
+++ b/src/einspect/types.py
@@ -53,5 +53,5 @@ class Array(CArray[_T]):
 if not TYPE_CHECKING:
     globals().update({
         "ptr": _Ptr,
-        "Array": ctypes.Array,
+        "Array": CArray,
     })

--- a/src/einspect/types.py
+++ b/src/einspect/types.py
@@ -1,4 +1,5 @@
 import ctypes
+import sys
 import typing
 from ctypes import pointer as ptr
 # noinspection PyUnresolvedReferences, PyProtectedMember
@@ -24,7 +25,16 @@ class _Ptr(_Pointer):
         return ctypes.POINTER(item)
 
 
-class Array(ctypes.Array[_T]):
+if sys.version_info >= (3, 9):
+    CArray = ctypes.Array
+else:
+    class _ArrayGenericAlias:
+        def __class_getitem__(cls, item):
+            return ctypes.Array
+    CArray = _ArrayGenericAlias
+
+
+class Array(CArray[_T]):
     _length_ = 0
     _type_ = ctypes.c_void_p
 

--- a/src/einspect/types.py
+++ b/src/einspect/types.py
@@ -4,7 +4,7 @@ import typing
 from ctypes import pointer as ptr
 # noinspection PyUnresolvedReferences, PyProtectedMember
 from ctypes import _Pointer
-from typing import TypeVar, TYPE_CHECKING, get_origin, overload
+from typing import List, TypeVar, TYPE_CHECKING, get_origin, overload
 
 __all__ = ("ptr", "Array")
 
@@ -43,7 +43,7 @@ class Array(CArray[_T]):
         ...
 
     @overload
-    def __getitem__(self, item: slice) -> list[_T]:
+    def __getitem__(self, item: slice) -> List[_T]:
         ...
 
     def __getitem__(self, item):

--- a/src/einspect/types.py
+++ b/src/einspect/types.py
@@ -1,0 +1,47 @@
+import ctypes
+import typing
+from ctypes import pointer as ptr
+# noinspection PyUnresolvedReferences, PyProtectedMember
+from ctypes import _Pointer
+from typing import TypeVar, TYPE_CHECKING, get_origin, overload
+
+__all__ = ("ptr", "Array")
+
+_T = TypeVar("_T")
+
+
+# noinspection PyPep8Naming
+class _Ptr(_Pointer):
+    def __new__(cls, *args, **kwargs):
+        return ctypes.pointer(*args, **kwargs)
+
+    def __class_getitem__(cls, item):
+        # Get base of generic alias
+        # noinspection PyUnresolvedReferences, PyProtectedMember
+        if isinstance(item, typing._GenericAlias):
+            item = get_origin(item)
+
+        return ctypes.POINTER(item)
+
+
+class Array(ctypes.Array[_T]):
+    _length_ = 0
+    _type_ = ctypes.c_void_p
+
+    @overload
+    def __getitem__(self, item: int) -> _T:
+        ...
+
+    @overload
+    def __getitem__(self, item: slice) -> list[_T]:
+        ...
+
+    def __getitem__(self, item):
+        raise NotImplementedError
+
+
+if not TYPE_CHECKING:
+    globals().update({
+        "ptr": _Ptr,
+        "Array": ctypes.Array,
+    })

--- a/src/einspect/views/__init__.py
+++ b/src/einspect/views/__init__.py
@@ -1,4 +1,4 @@
-from einspect.views.view_base import View, VarView
+from einspect.views.view_base import View, VarView, AnyView
 from einspect.views.view_set import SetView
 from einspect.views.view_bool import BoolView
 from einspect.views.view_dict import DictView

--- a/src/einspect/views/__init__.py
+++ b/src/einspect/views/__init__.py
@@ -1,0 +1,11 @@
+from einspect.views.view_base import View, VarView
+from einspect.views.view_set import SetView
+from einspect.views.view_bool import BoolView
+from einspect.views.view_dict import DictView
+from einspect.views.view_float import FloatView
+from einspect.views.view_int import IntView
+from einspect.views.view_list import ListView
+from einspect.views.view_mapping_proxy import MappingProxyView
+from einspect.views.view_set import SetView
+from einspect.views.view_str import StrView
+from einspect.views.view_tuple import TupleView

--- a/src/einspect/views/factory.py
+++ b/src/einspect/views/factory.py
@@ -11,6 +11,7 @@ from einspect.views.view_float import FloatView
 from einspect.views.view_int import IntView
 from einspect.views.view_list import ListView
 from einspect.views.view_mapping_proxy import MappingProxyView
+from einspect.views.view_set import SetView
 from einspect.views.view_str import StrView
 from einspect.views.view_tuple import TupleView
 
@@ -24,6 +25,7 @@ VIEW_TYPES: Final[dict[type, Type[View]]] = {
     list: ListView,
     tuple: TupleView,
     dict: DictView,
+    set: SetView,
     MappingProxyType: MappingProxyView,
 }
 """Mapping of (type): (view class)."""
@@ -60,6 +62,11 @@ def view(
 
 @overload
 def view(obj: dict[_KT, _VT], ref: bool = REF_DEFAULT) -> DictView[_KT, _VT]:
+    ...
+
+
+@overload
+def view(obj: set[_VT], ref: bool = REF_DEFAULT) -> SetView[_VT]:
     ...
 
 

--- a/src/einspect/views/factory.py
+++ b/src/einspect/views/factory.py
@@ -1,6 +1,7 @@
 """Function factory to create views for objects."""
 from __future__ import annotations
 
+import warnings
 from types import MappingProxyType
 from typing import Final, Type, TypeVar, overload, Any
 
@@ -18,6 +19,7 @@ from einspect.views.view_tuple import TupleView
 __all__ = ("view",)
 
 VIEW_TYPES: Final[dict[type, Type[View]]] = {
+    object: View,
     int: IntView,
     bool: BoolView,
     float: FloatView,
@@ -90,11 +92,6 @@ def view(obj: float, ref: bool = REF_DEFAULT) -> FloatView:
     ...
 
 
-@overload
-def view(obj: _T, ref: bool = REF_DEFAULT) -> View[_T]:
-    ...
-
-
 def view(obj, ref: bool = REF_DEFAULT):
     """
     Create a view onto a Python object.
@@ -110,5 +107,12 @@ def view(obj, ref: bool = REF_DEFAULT):
 
     if obj_type in VIEW_TYPES:
         return VIEW_TYPES[obj_type](obj, ref=ref)
-
-    return View(obj, ref=ref)
+    else:
+        res = View(obj, ref=ref)
+        msg = (
+            "Using `einspect.view` on objects without"
+            " a concrete View subclass will be deprecated."
+            " Use `einspect.views.AnyView` instead."
+        )
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        return res

--- a/src/einspect/views/view_base.py
+++ b/src/einspect/views/view_base.py
@@ -17,7 +17,7 @@ from einspect.structs import PyObject, PyVarObject
 from einspect.views._display import format_display
 from einspect.views.unsafe import UnsafeContext, unsafe
 
-__all__ = ("View", "VarView")
+__all__ = ("View", "VarView", "REF_DEFAULT")
 
 log = logging.getLogger(__name__)
 

--- a/src/einspect/views/view_bool.py
+++ b/src/einspect/views/view_bool.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-from ctypes import Array, c_uint32, addressof
-from typing import Iterable, TypeVar
-
-from einspect.api import Py_ssize_t
 from einspect.structs import PyBoolObject
 from einspect.utils import address
 from einspect.views.view_int import IntView
@@ -17,7 +13,7 @@ class BoolView(IntView):
     @property
     def mem_size(self) -> int:
         # If used on the singletons, use their
-        addr = addressof(self._pyobject)
+        addr = self._pyobject.address
         if addr == address(True):
             return True.__sizeof__()
         elif addr == address(False):

--- a/src/einspect/views/view_bool.py
+++ b/src/einspect/views/view_bool.py
@@ -10,8 +10,6 @@ from einspect.views.view_int import IntView
 
 __all__ = ("BoolView",)
 
-_T = TypeVar("_T")
-
 
 class BoolView(IntView):
     _pyobject: PyBoolObject

--- a/src/einspect/views/view_int.py
+++ b/src/einspect/views/view_int.py
@@ -42,7 +42,7 @@ class IntView(VarView[int, None, None]):
 
         # The new value's ob_size must be equal or less than the current
         new_size = abs(new_val.ob_size)
-        cur_size = abs(self._pyobject.ob_size)
+        cur_size = max(abs(self._pyobject.ob_size), 1)
         if new_size > cur_size:
             raise ValueError(f"New value {obj!r} too large")
 

--- a/src/einspect/views/view_set.py
+++ b/src/einspect/views/view_set.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from ctypes import cast, POINTER
+from typing import TypeVar
+
+from einspect.structs import PyObject
+from einspect.types import Array, ptr
+from einspect.structs.py_set import PySetObject, SetEntry
+from einspect.views.unsafe import unsafe
+from einspect.views.view_base import View, REF_DEFAULT
+
+__all__ = ("SetView",)
+
+_T = TypeVar("_T")
+
+
+class SetView(View[set, None, _T]):
+    _pyobject: PySetObject[_T]
+
+    def __init__(self, obj: set[_T], ref: bool = REF_DEFAULT) -> None:
+        super().__init__(obj, ref)
+
+    def __len__(self) -> int:
+        return self.used
+
+    @property
+    def fill(self) -> int:
+        return self._pyobject.fill
+
+    @fill.setter
+    @unsafe
+    def fill(self, value: int) -> None:
+        self._pyobject.fill = value
+
+    @property
+    def used(self) -> int:
+        return self._pyobject.used
+
+    @used.setter
+    @unsafe
+    def used(self, value: int) -> None:
+        self._pyobject.used = value
+
+    @property
+    def mask(self) -> int:
+        return self._pyobject.mask
+
+    @mask.setter
+    @unsafe
+    def mask(self, value: int) -> None:
+        self._pyobject.mask = value
+
+    @property
+    def table(self) -> Array[SetEntry[_T]]:
+        size = self.mask + 1
+        arr = cast(self._pyobject.table, POINTER(SetEntry * size))
+        return arr.contents
+
+    @property
+    def finger(self) -> int:
+        return self._pyobject.finger
+
+    @finger.setter
+    @unsafe
+    def finger(self, value: int) -> None:
+        self._pyobject.finger = value
+
+    @property
+    def smalltable(self) -> Array[SetEntry[_T]]:
+        return self._pyobject.smalltable
+
+    @smalltable.setter
+    @unsafe
+    def smalltable(self, value: Array[SetEntry[_T]]) -> None:
+        self._pyobject.smalltable = value
+
+    @property
+    def weakreflist(self) -> ptr[PyObject]:
+        return self._pyobject.weakreflist
+
+    @weakreflist.setter
+    @unsafe
+    def weakreflist(self, value: ptr[PyObject]) -> None:
+        self._pyobject.weakreflist = value
+

--- a/tests/views/test_view_set.py
+++ b/tests/views/test_view_set.py
@@ -1,0 +1,25 @@
+import pytest
+
+from einspect.structs import PySetObject
+from einspect.views.factory import view
+from einspect.views.view_set import SetView
+
+
+@pytest.fixture(scope="function")
+def obj() -> set[int]:
+    return {1, 2, 3}
+
+
+class TestSetView:
+    @pytest.mark.parametrize(["factory"], [
+        (view,),
+        (SetView,),
+    ])
+    def test_factory(self, obj, factory):
+        v = factory(obj)
+        assert isinstance(v, SetView)
+        assert isinstance(v._pyobject, PySetObject)
+        assert v.type == set
+        assert v.used == len(obj)
+        assert v.base.value is obj
+        assert ~v is obj

--- a/tests/views/test_view_set.py
+++ b/tests/views/test_view_set.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from einspect.structs import PySetObject


### PR DESCRIPTION
## New
- Added SetView using PySetObject struct

## Changes
- Add Deprecation warning for using `einspect.view` factory with unmapped object types that don't have a concrete `View` subclass implementation. Use `einspect.views.AnyView` instead

## Fixes
- Improved type inferencing for non-simple ctypes.Array and ctypes.pointer with the new `einspect.types` aliases

