### PR TITLE
Include header structs, new (GetAttr, SetAttr) PyObject bound apis

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,5 +29,5 @@ repos:
         additional_dependencies: [flake8-builtins]
         files: ^src/
         args:
-          - --ignore=W503,E203,F842,A003
+          - --ignore=W503,E203,F842,A003,F403,F405
           - --max-line-length=120

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,12 +17,6 @@ repos:
         name: isort (python)
         exclude: einspect/structs/__init__.py
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.3
-    hooks:
-      - id: pyupgrade
-        args: [--py38-plus]
-
   - repo: https://github.com/psf/black
     rev: 22.8.0
     hooks:
@@ -34,5 +28,5 @@ repos:
       - id: flake8
         additional_dependencies: [flake8-builtins]
         args:
-          - --ignore=W503,E203
-          - --max-line-length=88
+          - --ignore=W503,E203,F842
+          - --max-line-length=120

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies: [flake8-builtins]
+        files: ^src/
         args:
           - --ignore=W503,E203,F842,A003
           - --max-line-length=120

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
+        exclude: einspect/structs/__init__.py
 
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.37.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,6 @@ repos:
       - id: check-yaml
       - id: trailing-whitespace
       - id: end-of-file-fixer
-      - id: check-docstring-first
       - id: debug-statements
 
   - repo: https://github.com/pycqa/isort
@@ -15,6 +14,7 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
+        args: [ --profile=black ]
         exclude: einspect/structs/__init__.py
 
   - repo: https://github.com/psf/black
@@ -28,5 +28,5 @@ repos:
       - id: flake8
         additional_dependencies: [flake8-builtins]
         args:
-          - --ignore=W503,E203,F842
+          - --ignore=W503,E203,F842,A003
           - --max-line-length=120

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ print(tup)
 ```
 > ```
 > ('dog', 200)
-> 
+>
 > >> Process finished with exit code 139 (interrupted by signal 11: SIGSEGV)
 > ```
 
@@ -179,7 +179,7 @@ with view(tup).unsafe() as v:
     a = "bird"
     Py.IncRef(a)
     v.item[0] = id(a)
-    
+
     b = "kitten"
     Py.IncRef(b)
     v.item[1] = id(b)
@@ -187,7 +187,7 @@ with view(tup).unsafe() as v:
 print(tup)
 ```
 > `('bird', 'kitten')`
- 
+
 🎉 No more seg-faults, and we just successfully set both items in an otherwise immutable tuple.
 
 To make the above routine easier, you can access an abstraction by simply indexing the view.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
 project = "einspect"
 copyright = "2023, Ionite"
 author = "Ionite"
-release = "v0.3.1"
+release = "v0.4.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,7 @@ extensions = [
 ]
 
 # Autodoc style
-autodoc_member_order = 'groupwise'
+autodoc_member_order = "groupwise"
 
 # Prefix document path to section labels, to use:
 # `path/to/file:heading` instead of just `heading`
@@ -46,12 +46,12 @@ inline_highlight_respect_highlight = False
 inline_highlight_literals = False
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -59,9 +59,9 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'furo'
+html_theme = "furo"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]

--- a/docs/source/views.md
+++ b/docs/source/views.md
@@ -23,7 +23,7 @@ PyListObject(at 0x2833738):
 
 - All move operations require an unsafe context.
 
-The left shift operator `<<` / `<<=` can be used to copy memory from a right-side `View` (or object mappable to a supported `View` type) to the left-side view’s memory location. 
+The left shift operator `<<` / `<<=` can be used to copy memory from a right-side `View` (or object mappable to a supported `View` type) to the left-side view’s memory location.
 
 The operation returns a new view at the left side view’s memory location, created using the right-side view type.
 
@@ -41,7 +41,7 @@ for i in num:
     print(i)
 ```
 
-By default, the move is offset by sizeof(Py_ssize_t) to start after `ob_refcnt`. 
+By default, the move is offset by sizeof(Py_ssize_t) to start after `ob_refcnt`.
 
 The `View.move_from` function can also be used, equivalent to the `<<` operator. This function form allows an optional `offset` amount to be specified.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -343,6 +343,19 @@ docs = ["furo (>=2022.12.7)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.1
 testing = ["covdefaults (>=2.2.2)", "coverage (>=7.0.1)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-timeout (>=2.1)"]
 
 [[package]]
+name = "flake8"
+version = "6.0.0"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
+optional = false
+python-versions = ">=3.8.1"
+
+[package.dependencies]
+mccabe = ">=0.7.0,<0.8.0"
+pycodestyle = ">=2.10.0,<2.11.0"
+pyflakes = ">=3.0.0,<3.1.0"
+
+[[package]]
 name = "fqdn"
 version = "1.5.1"
 description = "Validates fully-qualified domain names against RFC 1123, so that they are acceptable to modern bowsers"
@@ -788,6 +801,14 @@ python-versions = ">=3.5"
 traitlets = "*"
 
 [[package]]
+name = "mccabe"
+version = "0.7.0"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "mdit-py-plugins"
 version = "0.3.3"
 description = "Collection of plugins for markdown-it-py"
@@ -1192,12 +1213,28 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "pycodestyle"
+version = "2.10.0"
+description = "Python style guide checker"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pyflakes"
+version = "3.0.1"
+description = "passive checker of Python programs"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "Pygments"
@@ -1796,8 +1833,8 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.8,<3.12"
-content-hash = "1d5f5d58d27098eb6baac6daadd303264d1d62e818352feb366134289621fd86"
+python-versions = ">=3.8.1,<3.12"
+content-hash = "95ac486f892ee8f42f3bbcb0f801aadef681b618eecce32f6eb44234b8cb8ff9"
 
 [metadata.files]
 alabaster = [
@@ -2067,12 +2104,16 @@ fastjsonschema = [
     {file = "fastjsonschema-2.16.2.tar.gz", hash = "sha256:01e366f25d9047816fe3d288cbfc3e10541daf0af2044763f3d0ade42476da18"},
 ]
 filelock = [
-    {file = "filelock-3.9.0-py3-none-any.whl", hash = "sha256:f58d535af89bb9ad5cd4df046f741f8553a418c01a7856bf0d173bbc9f6bd16d"},
-    {file = "filelock-3.9.0.tar.gz", hash = "sha256:7b319f24340b51f55a2bf7a12ac0755a9b03e718311dac567a0f4f7fabd2f5de"},
+    { file = "filelock-3.9.0-py3-none-any.whl", hash = "sha256:f58d535af89bb9ad5cd4df046f741f8553a418c01a7856bf0d173bbc9f6bd16d" },
+    { file = "filelock-3.9.0.tar.gz", hash = "sha256:7b319f24340b51f55a2bf7a12ac0755a9b03e718311dac567a0f4f7fabd2f5de" },
+]
+flake8 = [
+    { file = "flake8-6.0.0-py2.py3-none-any.whl", hash = "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7" },
+    { file = "flake8-6.0.0.tar.gz", hash = "sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181" },
 ]
 fqdn = [
-    {file = "fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014"},
-    {file = "fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f"},
+    { file = "fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014" },
+    { file = "fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f" },
 ]
 furo = [
     {file = "furo-2022.12.7-py3-none-any.whl", hash = "sha256:7cb76c12a25ef65db85ab0743df907573d03027a33631f17d267e598ebb191f7"},
@@ -2222,12 +2263,16 @@ MarkupSafe = [
     {file = "MarkupSafe-2.1.1.tar.gz", hash = "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b"},
 ]
 matplotlib-inline = [
-    {file = "matplotlib-inline-0.1.6.tar.gz", hash = "sha256:f887e5f10ba98e8d2b150ddcf4702c1e5f8b3a20005eb0f74bfdbd360ee6f304"},
-    {file = "matplotlib_inline-0.1.6-py3-none-any.whl", hash = "sha256:f1f41aab5328aa5aaea9b16d083b128102f8712542f819fe7e6a420ff581b311"},
+    { file = "matplotlib-inline-0.1.6.tar.gz", hash = "sha256:f887e5f10ba98e8d2b150ddcf4702c1e5f8b3a20005eb0f74bfdbd360ee6f304" },
+    { file = "matplotlib_inline-0.1.6-py3-none-any.whl", hash = "sha256:f1f41aab5328aa5aaea9b16d083b128102f8712542f819fe7e6a420ff581b311" },
+]
+mccabe = [
+    { file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e" },
+    { file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325" },
 ]
 mdit-py-plugins = [
-    {file = "mdit-py-plugins-0.3.3.tar.gz", hash = "sha256:5cfd7e7ac582a594e23ba6546a2f406e94e42eb33ae596d0734781261c251260"},
-    {file = "mdit_py_plugins-0.3.3-py3-none-any.whl", hash = "sha256:36d08a29def19ec43acdcd8ba471d3ebab132e7879d442760d963f19913e04b9"},
+    { file = "mdit-py-plugins-0.3.3.tar.gz", hash = "sha256:5cfd7e7ac582a594e23ba6546a2f406e94e42eb33ae596d0734781261c251260" },
+    { file = "mdit_py_plugins-0.3.3-py3-none-any.whl", hash = "sha256:36d08a29def19ec43acdcd8ba471d3ebab132e7879d442760d963f19913e04b9" },
 ]
 mdurl = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
@@ -2378,22 +2423,30 @@ pure-eval = [
     {file = "pure_eval-0.2.2.tar.gz", hash = "sha256:2b45320af6dfaa1750f543d714b6d1c520a1688dec6fd24d339063ce0aaa9ac3"},
 ]
 py = [
-    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
-    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+    { file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378" },
+    { file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719" },
+]
+pycodestyle = [
+    { file = "pycodestyle-2.10.0-py2.py3-none-any.whl", hash = "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610" },
+    { file = "pycodestyle-2.10.0.tar.gz", hash = "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053" },
 ]
 pycparser = [
-    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
-    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+    { file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9" },
+    { file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206" },
+]
+pyflakes = [
+    { file = "pyflakes-3.0.1-py2.py3-none-any.whl", hash = "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf" },
+    { file = "pyflakes-3.0.1.tar.gz", hash = "sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd" },
 ]
 Pygments = [
-    {file = "Pygments-2.14.0-py3-none-any.whl", hash = "sha256:fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717"},
-    {file = "Pygments-2.14.0.tar.gz", hash = "sha256:b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297"},
+    { file = "Pygments-2.14.0-py3-none-any.whl", hash = "sha256:fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717" },
+    { file = "Pygments-2.14.0.tar.gz", hash = "sha256:b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297" },
 ]
 pyrsistent = [
-    {file = "pyrsistent-0.19.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:20460ac0ea439a3e79caa1dbd560344b64ed75e85d8703943e0b66c2a6150e4a"},
-    {file = "pyrsistent-0.19.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c18264cb84b5e68e7085a43723f9e4c1fd1d935ab240ce02c0324a8e01ccb64"},
-    {file = "pyrsistent-0.19.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b774f9288dda8d425adb6544e5903f1fb6c273ab3128a355c6b972b7df39dcf"},
-    {file = "pyrsistent-0.19.3-cp310-cp310-win32.whl", hash = "sha256:5a474fb80f5e0d6c9394d8db0fc19e90fa540b82ee52dba7d246a7791712f74a"},
+    { file = "pyrsistent-0.19.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:20460ac0ea439a3e79caa1dbd560344b64ed75e85d8703943e0b66c2a6150e4a" },
+    { file = "pyrsistent-0.19.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c18264cb84b5e68e7085a43723f9e4c1fd1d935ab240ce02c0324a8e01ccb64" },
+    { file = "pyrsistent-0.19.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b774f9288dda8d425adb6544e5903f1fb6c273ab3128a355c6b972b7df39dcf" },
+    { file = "pyrsistent-0.19.3-cp310-cp310-win32.whl", hash = "sha256:5a474fb80f5e0d6c9394d8db0fc19e90fa540b82ee52dba7d246a7791712f74a" },
     {file = "pyrsistent-0.19.3-cp310-cp310-win_amd64.whl", hash = "sha256:49c32f216c17148695ca0e02a5c521e28a4ee6c5089f97e34fe24163113722da"},
     {file = "pyrsistent-0.19.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f0774bf48631f3a20471dd7c5989657b639fd2d285b861237ea9e82c36a415a9"},
     {file = "pyrsistent-0.19.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ab2204234c0ecd8b9368dbd6a53e83c3d4f3cab10ecaf6d0e772f456c442393"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1060,7 +1060,7 @@ test = ["pytest", "pytest-console-scripts", "pytest-tornasync"]
 
 [[package]]
 name = "packaging"
-version = "22.0"
+version = "23.0"
 description = "Core utilities for Python packages"
 category = "dev"
 optional = false
@@ -2104,16 +2104,16 @@ fastjsonschema = [
     {file = "fastjsonschema-2.16.2.tar.gz", hash = "sha256:01e366f25d9047816fe3d288cbfc3e10541daf0af2044763f3d0ade42476da18"},
 ]
 filelock = [
-    { file = "filelock-3.9.0-py3-none-any.whl", hash = "sha256:f58d535af89bb9ad5cd4df046f741f8553a418c01a7856bf0d173bbc9f6bd16d" },
-    { file = "filelock-3.9.0.tar.gz", hash = "sha256:7b319f24340b51f55a2bf7a12ac0755a9b03e718311dac567a0f4f7fabd2f5de" },
+    {file = "filelock-3.9.0-py3-none-any.whl", hash = "sha256:f58d535af89bb9ad5cd4df046f741f8553a418c01a7856bf0d173bbc9f6bd16d"},
+    {file = "filelock-3.9.0.tar.gz", hash = "sha256:7b319f24340b51f55a2bf7a12ac0755a9b03e718311dac567a0f4f7fabd2f5de"},
 ]
 flake8 = [
-    { file = "flake8-6.0.0-py2.py3-none-any.whl", hash = "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7" },
-    { file = "flake8-6.0.0.tar.gz", hash = "sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181" },
+    {file = "flake8-6.0.0-py2.py3-none-any.whl", hash = "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7"},
+    {file = "flake8-6.0.0.tar.gz", hash = "sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181"},
 ]
 fqdn = [
-    { file = "fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014" },
-    { file = "fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f" },
+    {file = "fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014"},
+    {file = "fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f"},
 ]
 furo = [
     {file = "furo-2022.12.7-py3-none-any.whl", hash = "sha256:7cb76c12a25ef65db85ab0743df907573d03027a33631f17d267e598ebb191f7"},
@@ -2263,16 +2263,16 @@ MarkupSafe = [
     {file = "MarkupSafe-2.1.1.tar.gz", hash = "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b"},
 ]
 matplotlib-inline = [
-    { file = "matplotlib-inline-0.1.6.tar.gz", hash = "sha256:f887e5f10ba98e8d2b150ddcf4702c1e5f8b3a20005eb0f74bfdbd360ee6f304" },
-    { file = "matplotlib_inline-0.1.6-py3-none-any.whl", hash = "sha256:f1f41aab5328aa5aaea9b16d083b128102f8712542f819fe7e6a420ff581b311" },
+    {file = "matplotlib-inline-0.1.6.tar.gz", hash = "sha256:f887e5f10ba98e8d2b150ddcf4702c1e5f8b3a20005eb0f74bfdbd360ee6f304"},
+    {file = "matplotlib_inline-0.1.6-py3-none-any.whl", hash = "sha256:f1f41aab5328aa5aaea9b16d083b128102f8712542f819fe7e6a420ff581b311"},
 ]
 mccabe = [
-    { file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e" },
-    { file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325" },
+    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
+    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
 ]
 mdit-py-plugins = [
-    { file = "mdit-py-plugins-0.3.3.tar.gz", hash = "sha256:5cfd7e7ac582a594e23ba6546a2f406e94e42eb33ae596d0734781261c251260" },
-    { file = "mdit_py_plugins-0.3.3-py3-none-any.whl", hash = "sha256:36d08a29def19ec43acdcd8ba471d3ebab132e7879d442760d963f19913e04b9" },
+    {file = "mdit-py-plugins-0.3.3.tar.gz", hash = "sha256:5cfd7e7ac582a594e23ba6546a2f406e94e42eb33ae596d0734781261c251260"},
+    {file = "mdit_py_plugins-0.3.3-py3-none-any.whl", hash = "sha256:36d08a29def19ec43acdcd8ba471d3ebab132e7879d442760d963f19913e04b9"},
 ]
 mdurl = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
@@ -2355,8 +2355,8 @@ notebook-shim = [
     {file = "notebook_shim-0.2.2.tar.gz", hash = "sha256:090e0baf9a5582ff59b607af523ca2db68ff216da0c69956b62cab2ef4fc9c3f"},
 ]
 packaging = [
-    {file = "packaging-22.0-py3-none-any.whl", hash = "sha256:957e2148ba0e1a3b282772e791ef1d8083648bc131c8ab0c1feba110ce1146c3"},
-    {file = "packaging-22.0.tar.gz", hash = "sha256:2198ec20bd4c017b8f9717e00f0c8714076fc2fd93816750ab48e2c41de2cfd3"},
+    {file = "packaging-23.0-py3-none-any.whl", hash = "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2"},
+    {file = "packaging-23.0.tar.gz", hash = "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"},
 ]
 pandocfilters = [
     {file = "pandocfilters-1.5.0-py2.py3-none-any.whl", hash = "sha256:33aae3f25fd1a026079f5d27bdd52496f0e0803b3469282162bafdcbdf6ef14f"},
@@ -2423,30 +2423,30 @@ pure-eval = [
     {file = "pure_eval-0.2.2.tar.gz", hash = "sha256:2b45320af6dfaa1750f543d714b6d1c520a1688dec6fd24d339063ce0aaa9ac3"},
 ]
 py = [
-    { file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378" },
-    { file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719" },
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 pycodestyle = [
-    { file = "pycodestyle-2.10.0-py2.py3-none-any.whl", hash = "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610" },
-    { file = "pycodestyle-2.10.0.tar.gz", hash = "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053" },
+    {file = "pycodestyle-2.10.0-py2.py3-none-any.whl", hash = "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610"},
+    {file = "pycodestyle-2.10.0.tar.gz", hash = "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053"},
 ]
 pycparser = [
-    { file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9" },
-    { file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206" },
+    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
+    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
 ]
 pyflakes = [
-    { file = "pyflakes-3.0.1-py2.py3-none-any.whl", hash = "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf" },
-    { file = "pyflakes-3.0.1.tar.gz", hash = "sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd" },
+    {file = "pyflakes-3.0.1-py2.py3-none-any.whl", hash = "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf"},
+    {file = "pyflakes-3.0.1.tar.gz", hash = "sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd"},
 ]
 Pygments = [
-    { file = "Pygments-2.14.0-py3-none-any.whl", hash = "sha256:fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717" },
-    { file = "Pygments-2.14.0.tar.gz", hash = "sha256:b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297" },
+    {file = "Pygments-2.14.0-py3-none-any.whl", hash = "sha256:fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717"},
+    {file = "Pygments-2.14.0.tar.gz", hash = "sha256:b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297"},
 ]
 pyrsistent = [
-    { file = "pyrsistent-0.19.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:20460ac0ea439a3e79caa1dbd560344b64ed75e85d8703943e0b66c2a6150e4a" },
-    { file = "pyrsistent-0.19.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c18264cb84b5e68e7085a43723f9e4c1fd1d935ab240ce02c0324a8e01ccb64" },
-    { file = "pyrsistent-0.19.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b774f9288dda8d425adb6544e5903f1fb6c273ab3128a355c6b972b7df39dcf" },
-    { file = "pyrsistent-0.19.3-cp310-cp310-win32.whl", hash = "sha256:5a474fb80f5e0d6c9394d8db0fc19e90fa540b82ee52dba7d246a7791712f74a" },
+    {file = "pyrsistent-0.19.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:20460ac0ea439a3e79caa1dbd560344b64ed75e85d8703943e0b66c2a6150e4a"},
+    {file = "pyrsistent-0.19.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c18264cb84b5e68e7085a43723f9e4c1fd1d935ab240ce02c0324a8e01ccb64"},
+    {file = "pyrsistent-0.19.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b774f9288dda8d425adb6544e5903f1fb6c273ab3128a355c6b972b7df39dcf"},
+    {file = "pyrsistent-0.19.3-cp310-cp310-win32.whl", hash = "sha256:5a474fb80f5e0d6c9394d8db0fc19e90fa540b82ee52dba7d246a7791712f74a"},
     {file = "pyrsistent-0.19.3-cp310-cp310-win_amd64.whl", hash = "sha256:49c32f216c17148695ca0e02a5c521e28a4ee6c5089f97e34fe24163113722da"},
     {file = "pyrsistent-0.19.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f0774bf48631f3a20471dd7c5989657b639fd2d285b861237ea9e82c36a415a9"},
     {file = "pyrsistent-0.19.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ab2204234c0ecd8b9368dbd6a53e83c3d4f3cab10ecaf6d0e772f456c442393"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "einspect"
-version = "0.3.1"
+version = "0.4.0"
 description = "Extended Inspect - view and modify memory structs of runtime objects."
 authors = ["ionite34 <dev@ionite.io>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,12 @@ myst-parser = "^0.18.1"
 sphinx-copybutton = "^0.5.1"
 furo = "^2022.12.7"
 
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "@overload"
+]
+
 [tool.isort]
 skip = ["einspect/structs/__init__.py"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "einspect"
-version = "0.4.0"
+version = "0.4.0a1"
 description = "Extended Inspect - view and modify memory structs of runtime objects."
 authors = ["ionite34 <dev@ionite.io>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
+python = ">=3.8.1,<3.12"
 typing-extensions = "^4.4.0"
 
 [tool.poetry.group.dev.dependencies]
@@ -16,6 +16,7 @@ pytest-cov = "^4.0.0"
 pytest-xdist = "^3.1.0"
 mypy = "^0.991"
 pre-commit = "^2.20.0"
+flake8 = "^6.0.0"
 
 [tool.poetry.group.dev-extras.dependencies]
 jupyter = "^1.0.0"
@@ -35,6 +36,9 @@ Sphinx = ">4.0.0,<6.0.0"
 myst-parser = "^0.18.1"
 sphinx-copybutton = "^0.5.1"
 furo = "^2022.12.7"
+
+[tool.isort]
+skip = ["einspect/structs/__init__.py"]
 
 [tool.pytest.ini_options]
 markers = [

--- a/src/einspect/__init__.py
+++ b/src/einspect/__init__.py
@@ -4,7 +4,6 @@ from typing import ContextManager
 
 from einspect.views.factory import view
 from einspect.views.unsafe import global_unsafe
-from einspect.views.view_base import View
 
 __all__ = ["view", "unsafe"]
 

--- a/src/einspect/api.py
+++ b/src/einspect/api.py
@@ -1,8 +1,9 @@
 """CPython API Methods."""
-import _ctypes
 import ctypes
 from ctypes import POINTER, py_object, pythonapi
-from typing import Union, Callable
+from typing import Callable, Union
+
+import _ctypes
 
 from einspect.compat import Version, python_req
 from einspect.protocols.delayed_bind import bind_api
@@ -74,7 +75,7 @@ class Py:
         """
         Set the item at position index in the tuple o to v.
         https://docs.python.org/3/c-api/tuple.html#c.PyTuple_SetItem
-        
+
         Notes:
             - This function steals a reference to v.
             - Requires tuple o to have a reference count == 1.

--- a/src/einspect/compat.py
+++ b/src/einspect/compat.py
@@ -11,7 +11,7 @@ from typing import Generic, NoReturn, TypeVar
 __all__ = ("Version", "RequiresPythonVersion", "python_req", "abc")
 
 if sys.version_info > (3, 8):
-    abc = typing
+    abc = typing  # noqa: F401, F811
 
 
 class Version(Enum):

--- a/src/einspect/protocols/delayed_bind.py
+++ b/src/einspect/protocols/delayed_bind.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from functools import partial
 from inspect import signature
 from types import MethodType
-from typing import Type, TypeVar, get_type_hints
+from typing import TypeVar, get_type_hints
 
 from einspect.protocols.type_parse import (
     FuncPtr,

--- a/src/einspect/protocols/delayed_bind.py
+++ b/src/einspect/protocols/delayed_bind.py
@@ -92,7 +92,7 @@ class delayed_bind(property):
         return arg_t, res_t
 
     # noinspection PyMethodOverriding
-    def __get__(self, instance: object | None, owner_cls: Type[_CT]) -> _F:
+    def __get__(self, instance: object | None, owner_cls: type[_CT]) -> _F:
         if self.attrname is None:
             raise TypeError(
                 "Cannot use bind instance without calling __set_name__ on it."

--- a/src/einspect/protocols/type_parse.py
+++ b/src/einspect/protocols/type_parse.py
@@ -5,12 +5,11 @@ import ctypes
 import logging
 import re
 import typing
+from ctypes import POINTER
+from typing import Any, Protocol, Sequence, TypeVar, get_origin, runtime_checkable
 
 # noinspection PyProtectedMember
 from _ctypes import _SimpleCData
-from ctypes import POINTER
-from typing import Any, Protocol, Sequence, TypeVar, runtime_checkable, get_origin
-
 from typing_extensions import Self
 
 log = logging.getLogger(__name__)

--- a/src/einspect/structs/__init__.py
+++ b/src/einspect/structs/__init__.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from einspect.structs.deco import struct
 from einspect.structs.mapping_proxy import MappingProxyObject
+from einspect.structs.py_bool import PyBoolObject
 from einspect.structs.py_dict import PyDictObject
 from einspect.structs.py_list import PyListObject
 from einspect.structs.py_long import PyLongObject
 from einspect.structs.py_object import PyObject, PyVarObject
+from einspect.structs.py_set import PySetObject
 from einspect.structs.py_tuple import PyTupleObject
 from einspect.structs.py_unicode import PyUnicodeObject
-from einspect.structs.py_bool import PyBoolObject
-from einspect.structs.py_set import PySetObject
 
 __all__ = (
     "deco",

--- a/src/einspect/structs/__init__.py
+++ b/src/einspect/structs/__init__.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
 from einspect.structs.deco import struct
-from einspect.structs.mapping_proxy import MappingProxyObject
-from einspect.structs.py_bool import PyBoolObject
-from einspect.structs.py_dict import PyDictObject
-from einspect.structs.py_list import PyListObject
-from einspect.structs.py_long import PyLongObject
 from einspect.structs.py_object import PyObject, PyVarObject
-from einspect.structs.py_set import PySetObject
-from einspect.structs.py_tuple import PyTupleObject
+from einspect.structs.py_long import PyLongObject
+from einspect.structs.py_bool import PyBoolObject
 from einspect.structs.py_unicode import PyUnicodeObject
+from einspect.structs.py_list import PyListObject
+from einspect.structs.py_tuple import PyTupleObject
+from einspect.structs.py_set import PySetObject
+from einspect.structs.py_dict import PyDictObject
+from einspect.structs.mapping_proxy import MappingProxyObject
 
 __all__ = (
-    "deco",
+    "struct",
     "PyObject",
     "PyVarObject",
     "PyTupleObject",

--- a/src/einspect/structs/deco.py
+++ b/src/einspect/structs/deco.py
@@ -3,20 +3,10 @@ from __future__ import annotations
 import logging
 from ctypes import Structure
 from functools import partial
-from typing import (
-    Callable,
-    Literal,
-    Sequence,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    get_type_hints,
-    overload,
-)
+from typing import Callable, Literal, Sequence, Tuple, Type, TypeVar, Union, overload
 
 # noinspection PyUnresolvedReferences, PyProtectedMember
-from typing_extensions import _AnnotatedAlias, get_args
+from typing_extensions import _AnnotatedAlias, get_args, get_type_hints
 
 from einspect.protocols.type_parse import convert_type_hints, fix_ctypes_generics
 

--- a/src/einspect/structs/deco.py
+++ b/src/einspect/structs/deco.py
@@ -3,11 +3,20 @@ from __future__ import annotations
 import logging
 from ctypes import Structure
 from functools import partial
-from typing import Callable, Literal, Sequence, Tuple, Type, TypeVar, Union, overload
+from typing import (
+    Callable,
+    Literal,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    get_type_hints,
+    overload,
+)
 
 # noinspection PyUnresolvedReferences, PyProtectedMember
 from typing_extensions import _AnnotatedAlias, get_args
-from typing import get_type_hints
 
 from einspect.protocols.type_parse import convert_type_hints, fix_ctypes_generics
 

--- a/src/einspect/structs/deco.py
+++ b/src/einspect/structs/deco.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import logging
 from ctypes import Structure
 from functools import partial
-from typing import Callable, Type, TypeVar, overload, Union, Sequence, Tuple, Literal
+from typing import Callable, Literal, Sequence, Tuple, Type, TypeVar, Union, overload
 
 # noinspection PyUnresolvedReferences, PyProtectedMember
-from typing_extensions import _AnnotatedAlias, get_type_hints, get_args
+from typing_extensions import _AnnotatedAlias, get_args
+from typing import get_type_hints
 
 from einspect.protocols.type_parse import convert_type_hints, fix_ctypes_generics
 
@@ -42,9 +43,7 @@ def struct(cls: _T | None = None, fields: FieldsType | None = None):
 def _struct(cls: _T, __fields: FieldsType | None = None) -> _T:
     """Decorator to declare _fields_ on Structures via type hints."""
     # if fields provided, replace type hints with temp sentinel
-    fields_overrides = {
-        tup[0]: tup for tup in __fields or ()
-    }
+    fields_overrides = {tup[0]: tup for tup in __fields or ()}
     if __fields is not None:
         for tup in __fields:
             # This is to prevent errors during get_type_hints if there is an override

--- a/src/einspect/structs/include/descrobject_h.py
+++ b/src/einspect/structs/include/descrobject_h.py
@@ -1,0 +1,28 @@
+from ctypes import PYFUNCTYPE, Structure, c_char_p, c_int, c_void_p, py_object
+
+from typing_extensions import Annotated
+
+from einspect.structs import struct
+
+__all__ = ("getter", "setter", "PyMemberDef", "PyGetSetDef")
+
+getter = PYFUNCTYPE(py_object, py_object, py_object)
+setter = PYFUNCTYPE(c_int, py_object, py_object, c_void_p)
+
+
+@struct
+class PyMemberDef(Structure):
+    name: c_char_p
+    type: Annotated[int, c_int]
+    offset: int
+    flags: Annotated[int, c_int]
+    doc: c_char_p
+
+
+@struct
+class PyGetSetDef(Structure):
+    name: c_char_p
+    get: getter
+    set: setter
+    doc: c_char_p
+    closure: c_void_p

--- a/src/einspect/structs/include/methodobject_h.py
+++ b/src/einspect/structs/include/methodobject_h.py
@@ -1,0 +1,16 @@
+from ctypes import PYFUNCTYPE, Structure, c_char, c_char_p, c_int, py_object
+from typing import Annotated
+
+from einspect.structs import struct
+
+__all__ = ("PyMethodDef", "PyCFunction")
+
+PyCFunction = PYFUNCTYPE(py_object, py_object, py_object)
+
+
+@struct
+class PyMethodDef(Structure):
+    ml_name: c_char
+    ml_meth: PyCFunction
+    ml_flags: Annotated[int, c_int]
+    ml_doc: c_char_p

--- a/src/einspect/structs/include/object_h.py
+++ b/src/einspect/structs/include/object_h.py
@@ -1,0 +1,205 @@
+"""https://github.com/python/cpython/blob/3.11/Include/object.h"""
+from ctypes import PYFUNCTYPE, Structure, c_char_p, c_int, c_void_p, py_object
+from enum import IntEnum
+
+from einspect.api import Py_ssize_t
+from einspect.structs.deco import struct
+from einspect.types import ptr
+
+__all__ = (
+    "unaryfunc",
+    "binaryfunc",
+    "ternaryfunc",
+    "inquiry",
+    "lenfunc",
+    "ssizeargfunc",
+    "ssizessizeargfunc",
+    "ssizeobjargproc",
+    "ssizessizeobjargproc",
+    "objobjargproc",
+    "objobjproc",
+    "visitproc",
+    "traverseproc",
+    "freefunc",
+    "destructor",
+    "getattrfunc",
+    "getattrofunc",
+    "setattrfunc",
+    "setattrofunc",
+    "reprfunc",
+    "hashfunc",
+    "richcmpfunc",
+    "getiterfunc",
+    "iternextfunc",
+    "descrgetfunc",
+    "descrsetfunc",
+    "initproc",
+    "newfunc",
+    "allocfunc",
+    "vectorcallfunc",
+    "sendfunc",
+    "PyAsyncMethods",
+    "PyNumberMethods",
+    "PyMappingMethods",
+    "PySequenceMethods",
+)
+
+
+# Function types
+# https://github.com/python/cpython/blob/3.11/Include/object.h#L196-L227
+
+# typedef PyObject * (*unaryfunc)(PyObject *);
+unaryfunc = PYFUNCTYPE(py_object, py_object)
+# typedef PyObject * (*binaryfunc)(PyObject *, PyObject *);
+binaryfunc = PYFUNCTYPE(py_object, py_object, py_object)
+# typedef PyObject * (*ternaryfunc)(PyObject *, PyObject *, PyObject *);
+ternaryfunc = PYFUNCTYPE(py_object, py_object, py_object, py_object)
+# typedef int (*inquiry)(PyObject *);
+inquiry = PYFUNCTYPE(c_int, py_object)
+# typedef Py_ssize_t (*lenfunc)(PyObject *);
+lenfunc = PYFUNCTYPE(Py_ssize_t, py_object)
+# typedef PyObject *(*ssizeargfunc)(PyObject *, Py_ssize_t);
+ssizeargfunc = PYFUNCTYPE(py_object, py_object, Py_ssize_t)
+# typedef PyObject *(*ssizessizeargfunc)(PyObject *, Py_ssize_t, Py_ssize_t);
+ssizessizeargfunc = PYFUNCTYPE(py_object, py_object, Py_ssize_t, Py_ssize_t)
+# typedef int(*ssizeobjargproc)(PyObject *, Py_ssize_t, PyObject *);
+ssizeobjargproc = PYFUNCTYPE(c_int, py_object, Py_ssize_t, py_object)
+# typedef int(*ssizessizeobjargproc)(PyObject *, Py_ssize_t, Py_ssize_t, PyObject *);
+ssizessizeobjargproc = PYFUNCTYPE(c_int, py_object, Py_ssize_t, Py_ssize_t, py_object)
+# typedef int(*objobjargproc)(PyObject *, PyObject *, PyObject *);
+objobjargproc = PYFUNCTYPE(c_int, py_object, py_object, py_object)
+
+# typedef int (*objobjproc)(PyObject *, PyObject *);
+objobjproc = PYFUNCTYPE(c_int, py_object, py_object)
+# typedef int (*visitproc)(PyObject *, void *);
+visitproc = PYFUNCTYPE(c_int, py_object, c_void_p)
+# typedef int (*traverseproc)(PyObject *, visitproc, void *);
+traverseproc = PYFUNCTYPE(c_int, py_object, visitproc, c_void_p)
+
+# typedef void (*freefunc)(void *);
+freefunc = PYFUNCTYPE(None, c_void_p)
+# typedef void (*destructor)(PyObject *);
+destructor = PYFUNCTYPE(None, py_object)
+# typedef PyObject *(*getattrfunc)(PyObject *, char *);
+getattrfunc = PYFUNCTYPE(py_object, py_object, c_char_p)
+# typedef PyObject *(*getattrofunc)(PyObject *, PyObject *);
+getattrofunc = PYFUNCTYPE(py_object, py_object, py_object)
+# typedef int (*setattrfunc)(PyObject *, char *, PyObject *);
+setattrfunc = PYFUNCTYPE(c_int, py_object, c_char_p, py_object)
+# typedef int (*setattrofunc)(PyObject *, PyObject *, PyObject *);
+setattrofunc = PYFUNCTYPE(c_int, py_object, py_object, py_object)
+# typedef PyObject *(*reprfunc)(PyObject *);
+reprfunc = PYFUNCTYPE(py_object, py_object)
+# typedef Py_hash_t (*hashfunc)(PyObject *);
+hashfunc = PYFUNCTYPE(Py_ssize_t, py_object)
+# typedef PyObject *(*richcmpfunc) (PyObject *, PyObject *, int);
+richcmpfunc = PYFUNCTYPE(py_object, py_object, py_object, c_int)
+# typedef PyObject *(*getiterfunc) (PyObject *);
+getiterfunc = PYFUNCTYPE(py_object, py_object)
+# typedef PyObject *(*iternextfunc) (PyObject *);
+iternextfunc = PYFUNCTYPE(py_object, py_object)
+
+# typedef PyObject *(*descrgetfunc) (PyObject *, PyObject *, PyObject *);
+descrgetfunc = PYFUNCTYPE(py_object, py_object, py_object, py_object)
+# typedef int (*descrsetfunc) (PyObject *, PyObject *, PyObject *);
+descrsetfunc = PYFUNCTYPE(c_int, py_object, py_object, py_object)
+# typedef int (*initproc)(PyObject *, PyObject *, PyObject *);
+initproc = PYFUNCTYPE(c_int, py_object, py_object, py_object)
+# typedef PyObject *(*newfunc)(PyTypeObject *, PyObject *, PyObject *);
+newfunc = PYFUNCTYPE(py_object, py_object, py_object, py_object)
+# typedef PyObject *(*allocfunc)(PyTypeObject *, Py_ssize_t);
+allocfunc = PYFUNCTYPE(py_object, py_object, Py_ssize_t)
+
+# typedef PyObject *(*vectorcallfunc)(PyObject *callable, PyObject *const *args, size_t nargsf, PyObject *kwnames)
+vectorcallfunc = PYFUNCTYPE(py_object, py_object, ptr[py_object], Py_ssize_t, py_object)
+
+
+class PySendResult(IntEnum):
+    """Result of calling PyIter_Send."""
+
+    PYGEN_RETURN = 0
+    PYGEN_ERROR = -1
+    PYGEN_NEXT = 1
+
+
+# typedef PySendResult (*sendfunc)(PyObject *iter, PyObject *value, PyObject **result);
+sendfunc = PYFUNCTYPE(c_int, py_object, py_object, ptr[py_object])
+
+
+@struct
+class PyAsyncMethods(Structure):
+    am_await: unaryfunc
+    am_aiter: unaryfunc
+    am_anext: unaryfunc
+    am_send: sendfunc
+
+
+@struct
+class PyNumberMethods(Structure):
+    """
+    Number implementations must check *both*
+    arguments for proper type and implement the necessary conversions
+    in the slot functions themselves.
+    """
+
+    nb_add: binaryfunc
+    nb_subtract: binaryfunc
+    nb_multiply: binaryfunc
+    nb_remainder: binaryfunc
+    nb_divmod: binaryfunc
+    nb_power: ternaryfunc
+    nb_negative: unaryfunc
+    nb_positive: unaryfunc
+    nb_absolute: unaryfunc
+    nb_bool: inquiry
+    nb_invert: unaryfunc
+    nb_lshift: binaryfunc
+    nb_rshift: binaryfunc
+    nb_and: binaryfunc
+    nb_xor: binaryfunc
+    nb_or: binaryfunc
+    nb_int: unaryfunc
+    nb_reserved: c_void_p  # formerly nb_long
+    nb_float: unaryfunc
+
+    nb_inplace_add: binaryfunc
+    nb_inplace_subtract: binaryfunc
+    nb_inplace_multiply: binaryfunc
+    nb_inplace_remainder: binaryfunc
+    nb_inplace_power: ternaryfunc
+    nb_inplace_lshift: binaryfunc
+    nb_inplace_rshift: binaryfunc
+    nb_inplace_and: binaryfunc
+    nb_inplace_xor: binaryfunc
+    nb_inplace_or: binaryfunc
+
+    nb_floor_divide: binaryfunc
+    nb_true_divide: binaryfunc
+    nb_inplace_floor_divide: binaryfunc
+    nb_inplace_true_divide: binaryfunc
+
+    nb_index: unaryfunc
+
+    nb_matrix_multiply: binaryfunc
+    nb_inplace_matrix_multiply: binaryfunc
+
+
+@struct
+class PyMappingMethods(Structure):
+    mp_length: lenfunc
+    mp_subscript: binaryfunc
+    mp_ass_subscript: objobjargproc
+
+
+@struct
+class PySequenceMethods(Structure):
+    sq_length: lenfunc
+    sq_concat: binaryfunc
+    sq_repeat: ssizeargfunc
+    sq_item: ssizeargfunc
+    was_sq_slice: c_void_p
+    sq_ass_item: ssizeobjargproc
+    was_sq_ass_slice: c_void_p
+    sq_contains: objobjproc
+    sq_inplace_concat: binaryfunc
+    sq_inplace_repeat: ssizeargfunc

--- a/src/einspect/structs/include/object_h.py
+++ b/src/einspect/structs/include/object_h.py
@@ -38,80 +38,53 @@ __all__ = (
     "allocfunc",
     "vectorcallfunc",
     "sendfunc",
+    "PySendResult",
+    "TpFlags",
     "PyAsyncMethods",
     "PyNumberMethods",
     "PyMappingMethods",
     "PySequenceMethods",
 )
 
-
 # Function types
 # https://github.com/python/cpython/blob/3.11/Include/object.h#L196-L227
-
-# typedef PyObject * (*unaryfunc)(PyObject *);
 unaryfunc = PYFUNCTYPE(py_object, py_object)
-# typedef PyObject * (*binaryfunc)(PyObject *, PyObject *);
 binaryfunc = PYFUNCTYPE(py_object, py_object, py_object)
-# typedef PyObject * (*ternaryfunc)(PyObject *, PyObject *, PyObject *);
 ternaryfunc = PYFUNCTYPE(py_object, py_object, py_object, py_object)
-# typedef int (*inquiry)(PyObject *);
 inquiry = PYFUNCTYPE(c_int, py_object)
-# typedef Py_ssize_t (*lenfunc)(PyObject *);
 lenfunc = PYFUNCTYPE(Py_ssize_t, py_object)
-# typedef PyObject *(*ssizeargfunc)(PyObject *, Py_ssize_t);
 ssizeargfunc = PYFUNCTYPE(py_object, py_object, Py_ssize_t)
-# typedef PyObject *(*ssizessizeargfunc)(PyObject *, Py_ssize_t, Py_ssize_t);
 ssizessizeargfunc = PYFUNCTYPE(py_object, py_object, Py_ssize_t, Py_ssize_t)
-# typedef int(*ssizeobjargproc)(PyObject *, Py_ssize_t, PyObject *);
 ssizeobjargproc = PYFUNCTYPE(c_int, py_object, Py_ssize_t, py_object)
-# typedef int(*ssizessizeobjargproc)(PyObject *, Py_ssize_t, Py_ssize_t, PyObject *);
 ssizessizeobjargproc = PYFUNCTYPE(c_int, py_object, Py_ssize_t, Py_ssize_t, py_object)
-# typedef int(*objobjargproc)(PyObject *, PyObject *, PyObject *);
 objobjargproc = PYFUNCTYPE(c_int, py_object, py_object, py_object)
 
-# typedef int (*objobjproc)(PyObject *, PyObject *);
 objobjproc = PYFUNCTYPE(c_int, py_object, py_object)
-# typedef int (*visitproc)(PyObject *, void *);
 visitproc = PYFUNCTYPE(c_int, py_object, c_void_p)
-# typedef int (*traverseproc)(PyObject *, visitproc, void *);
 traverseproc = PYFUNCTYPE(c_int, py_object, visitproc, c_void_p)
 
-# typedef void (*freefunc)(void *);
 freefunc = PYFUNCTYPE(None, c_void_p)
-# typedef void (*destructor)(PyObject *);
 destructor = PYFUNCTYPE(None, py_object)
-# typedef PyObject *(*getattrfunc)(PyObject *, char *);
 getattrfunc = PYFUNCTYPE(py_object, py_object, c_char_p)
-# typedef PyObject *(*getattrofunc)(PyObject *, PyObject *);
 getattrofunc = PYFUNCTYPE(py_object, py_object, py_object)
-# typedef int (*setattrfunc)(PyObject *, char *, PyObject *);
 setattrfunc = PYFUNCTYPE(c_int, py_object, c_char_p, py_object)
-# typedef int (*setattrofunc)(PyObject *, PyObject *, PyObject *);
 setattrofunc = PYFUNCTYPE(c_int, py_object, py_object, py_object)
-# typedef PyObject *(*reprfunc)(PyObject *);
 reprfunc = PYFUNCTYPE(py_object, py_object)
-# typedef Py_hash_t (*hashfunc)(PyObject *);
 hashfunc = PYFUNCTYPE(Py_ssize_t, py_object)
-# typedef PyObject *(*richcmpfunc) (PyObject *, PyObject *, int);
 richcmpfunc = PYFUNCTYPE(py_object, py_object, py_object, c_int)
-# typedef PyObject *(*getiterfunc) (PyObject *);
 getiterfunc = PYFUNCTYPE(py_object, py_object)
-# typedef PyObject *(*iternextfunc) (PyObject *);
 iternextfunc = PYFUNCTYPE(py_object, py_object)
 
-# typedef PyObject *(*descrgetfunc) (PyObject *, PyObject *, PyObject *);
 descrgetfunc = PYFUNCTYPE(py_object, py_object, py_object, py_object)
-# typedef int (*descrsetfunc) (PyObject *, PyObject *, PyObject *);
 descrsetfunc = PYFUNCTYPE(c_int, py_object, py_object, py_object)
-# typedef int (*initproc)(PyObject *, PyObject *, PyObject *);
 initproc = PYFUNCTYPE(c_int, py_object, py_object, py_object)
-# typedef PyObject *(*newfunc)(PyTypeObject *, PyObject *, PyObject *);
 newfunc = PYFUNCTYPE(py_object, py_object, py_object, py_object)
-# typedef PyObject *(*allocfunc)(PyTypeObject *, Py_ssize_t);
 allocfunc = PYFUNCTYPE(py_object, py_object, Py_ssize_t)
 
-# typedef PyObject *(*vectorcallfunc)(PyObject *callable, PyObject *const *args, size_t nargsf, PyObject *kwnames)
+# PyObject *(*vectorcallfunc)(PyObject *callable, PyObject *const *args, size_t nargsf, PyObject *kwnames)
 vectorcallfunc = PYFUNCTYPE(py_object, py_object, ptr[py_object], Py_ssize_t, py_object)
+# PySendResult (*sendfunc)(PyObject *iter, PyObject *value, PyObject **result)
+sendfunc = PYFUNCTYPE(c_int, py_object, py_object, ptr[py_object])
 
 
 class PySendResult(IntEnum):
@@ -122,8 +95,63 @@ class PySendResult(IntEnum):
     PYGEN_NEXT = 1
 
 
-# typedef PySendResult (*sendfunc)(PyObject *iter, PyObject *value, PyObject **result);
-sendfunc = PYFUNCTYPE(c_int, py_object, py_object, ptr[py_object])
+class TpFlags(IntEnum):
+    """
+    Type flags (tp_flags)
+
+    https://github.com/python/cpython/blob/3.11/Include/object.h#L350-L440
+    """
+
+    STATIC_BUILTIN = 1 << 1
+    MANAGED_WEAKREF = 1 << 3
+    MANAGED_DICT = 1 << 4
+    PREHEADER = MANAGED_WEAKREF | MANAGED_DICT
+    # Set if instances of the type object are treated as sequences for pattern matching
+    SEQUENCE = 1 << 5
+    # Set if instances of the type object are treated as mappings for pattern matching
+    MAPPING = 1 << 6
+    # Disallow creating instances of the type: set tp_new to NULL and don't create
+    # the "__new__" key in the type dictionary.
+    DISALLOW_INSTANTIATION = 1 << 7
+    # Set if the type object is immutable: type attributes cannot be set nor deleted
+    IMMUTABLETYPE = 1 << 8
+    # Set if the type object is dynamically allocated
+    HEAPTYPE = 1 << 9
+    # Set if the type allows subclassing
+    BASETYPE = 1 << 10
+    # Set if the type implements the vectorcall protocol (PEP 590)
+    HAVE_VECTORCALL = 1 << 11
+    # Set if the type is 'ready' -- fully initialized
+    READY = 1 << 12
+    # Set while the type is being 'readied', to prevent recursive ready calls
+    READYING = 1 << 13
+    # Objects support garbage collection (see objimpl.h)
+    HAVE_GC = 1 << 14
+    # These two bits are preserved for Stackless Python, next after this is 17
+    HAVE_STACKLESS_EXTENSION = 0  # if STACKLESS (3 << 15)
+    # Objects behave like an unbound method
+    METHOD_DESCRIPTOR = 1 << 17
+    # Object has up-to-date type attribute cache
+    VALID_VERSION_TAG = 1 << 19
+    # Type is abstract and cannot be instantiated
+    IS_ABSTRACT = 1 << 20
+    # This undocumented flag gives certain built-ins their unique pattern-matching
+    # behavior, which allows a single positional subpattern to match against the
+    # subject itself (rather than a mapped attribute on it):
+    MATCH_SELF = 1 << 22
+    # These flags are used to determine if a type is a subclass.
+    LONG_SUBCLASS = 1 << 24
+    LIST_SUBCLASS = 1 << 25
+    TUPLE_SUBCLASS = 1 << 26
+    BYTES_SUBCLASS = 1 << 27
+    UNICODE_SUBCLASS = 1 << 28
+    DICT_SUBCLASS = 1 << 29
+    BASE_EXC_SUBCLASS = 1 << 30
+    TYPE_SUBCLASS = 1 << 31
+    DEFAULT = HAVE_STACKLESS_EXTENSION | 0
+    # Some of these flags reuse lower bits (removed as part of the Python 3.0 transition).
+    HAVE_FINALIZE = 1 << 0
+    HAVE_VERSION_TAG = 1 << 18
 
 
 @struct

--- a/src/einspect/structs/include/object_h.py
+++ b/src/einspect/structs/include/object_h.py
@@ -4,6 +4,7 @@ from enum import IntEnum
 
 from einspect.api import Py_ssize_t
 from einspect.structs.deco import struct
+from einspect.structs.include.pybuffer_h import getbufferproc, releasebufferproc
 from einspect.types import ptr
 
 __all__ = (
@@ -40,6 +41,7 @@ __all__ = (
     "sendfunc",
     "PySendResult",
     "TpFlags",
+    "PyBufferProcs",
     "PyAsyncMethods",
     "PyNumberMethods",
     "PyMappingMethods",
@@ -160,6 +162,12 @@ class PyAsyncMethods(Structure):
     am_aiter: unaryfunc
     am_anext: unaryfunc
     am_send: sendfunc
+
+
+@struct
+class PyBufferProcs(Structure):
+    bf_getbuffer: getbufferproc
+    bf_releasebuffer: releasebufferproc
 
 
 @struct

--- a/src/einspect/structs/include/pybuffer_h.py
+++ b/src/einspect/structs/include/pybuffer_h.py
@@ -1,0 +1,27 @@
+from ctypes import PYFUNCTYPE, Structure, c_int, c_void_p, py_object
+
+from einspect.api import Py_ssize_t
+from einspect.structs import PyObject, struct
+from einspect.types import ptr
+
+__all__ = ("Py_buffer", "getbufferproc", "releasebufferproc")
+
+
+# noinspection PyPep8Naming
+@struct
+class Py_buffer(Structure):
+    buf: c_void_p
+    obj: ptr[PyObject]  # owned reference
+    len: Py_ssize_t
+    itemsize: Py_ssize_t  # Py_ssize_t so it can be pointed to by strides in simple case
+    readonly: c_int
+    ndim: c_int
+    format: c_void_p
+    shape: ptr[Py_ssize_t]
+    strides: ptr[Py_ssize_t]
+    suboffsets: ptr[Py_ssize_t]
+    internal: c_void_p
+
+
+getbufferproc = PYFUNCTYPE(c_int, py_object, Py_buffer, c_int)
+releasebufferproc = PYFUNCTYPE(None, py_object, Py_buffer)

--- a/src/einspect/structs/mapping_proxy.py
+++ b/src/einspect/structs/mapping_proxy.py
@@ -28,4 +28,4 @@ class MappingProxyObject(PyObject[MappingProxyType, _KT, _VT_co]):
         cls, obj: MappingProxyType[_KT, _VT_co]
     ) -> MappingProxyObject[MappingProxyType, _KT, _VT_co]:
         """Create a MappingProxyObject from an object."""
-        return super(MappingProxyObject, cls).from_object(obj)  # type: ignore
+        return super().from_object(obj)  # type: ignore

--- a/src/einspect/structs/py_dict.py
+++ b/src/einspect/structs/py_dict.py
@@ -2,16 +2,16 @@ from __future__ import annotations
 
 from ctypes import (
     POINTER,
+    Structure,
+    c_char,
     c_ssize_t,
+    c_uint8,
+    c_uint32,
     c_uint64,
     c_void_p,
     pythonapi,
-    c_char,
-    c_uint32,
-    c_uint8,
-    Structure,
 )
-from typing import TypeVar, Dict
+from typing import Dict, TypeVar
 
 from einspect.api import Py_ssize_t
 from einspect.protocols.delayed_bind import bind_api
@@ -93,6 +93,6 @@ class PyDictObject(PyObject[dict, _KT, _VT]):
         """
 
     @classmethod
-    def from_object(cls, obj: Dict[_KT, _VT]) -> PyDictObject[_KT, _VT]:
+    def from_object(cls, obj: dict[_KT, _VT]) -> PyDictObject[_KT, _VT]:
         """Create a PyDictObject from an object."""
-        return super(PyDictObject, cls).from_object(obj)  # type: ignore
+        return super().from_object(obj)  # type: ignore

--- a/src/einspect/structs/py_dict.py
+++ b/src/einspect/structs/py_dict.py
@@ -93,6 +93,6 @@ class PyDictObject(PyObject[dict, _KT, _VT]):
         """
 
     @classmethod
-    def from_object(cls, obj: dict[_KT, _VT]) -> PyDictObject[_KT, _VT]:
+    def from_object(cls, obj: Dict[_KT, _VT]) -> PyDictObject[_KT, _VT]:
         """Create a PyDictObject from an object."""
         return super().from_object(obj)  # type: ignore

--- a/src/einspect/structs/py_list.py
+++ b/src/einspect/structs/py_list.py
@@ -66,5 +66,5 @@ class PyListObject(PyVarObject[list, None, _VT]):
         """Set a value to a given index."""
 
     @bind_api(pythonapi["PyList_SetSlice"])
-    def SetSlice(self, low: int, high: int, item_list: list[_VT]) -> None:
+    def SetSlice(self, low: int, high: int, item_list: List[_VT]) -> None:
         """Set a value to a given index."""

--- a/src/einspect/structs/py_list.py
+++ b/src/einspect/structs/py_list.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 from ctypes import POINTER, c_long, pythonapi
-from typing import TypeVar, List
+from typing import List, TypeVar
 
 from typing_extensions import Annotated
 
-from einspect.types import ptr
 from einspect.protocols.delayed_bind import bind_api
 from einspect.structs.deco import struct
-from einspect.structs.py_object import PyObject, PyVarObject, Fields
+from einspect.structs.py_object import Fields, PyObject, PyVarObject
+from einspect.types import ptr
 
 _VT = TypeVar("_VT")
 
@@ -26,14 +26,14 @@ class PyListObject(PyVarObject[list, None, _VT]):
     allocated: Annotated[int, c_long]
 
     @classmethod
-    def from_object(cls, obj: List[_VT]) -> PyListObject[_VT]:
+    def from_object(cls, obj: list[_VT]) -> PyListObject[_VT]:
         return cls.from_address(id(obj))
 
     def _format_fields_(self) -> Fields:
         return {
             **super()._format_fields_(),
             "ob_item": ("**PyObject", ptr[ptr[PyObject] * self.allocated]),
-            "allocated": "c_long"
+            "allocated": "c_long",
         }
 
     @bind_api(pythonapi["PyList_GetItem"])
@@ -66,5 +66,5 @@ class PyListObject(PyVarObject[list, None, _VT]):
         """Set a value to a given index."""
 
     @bind_api(pythonapi["PyList_SetSlice"])
-    def SetSlice(self, low: int, high: int, item_list: List[_VT]) -> None:
+    def SetSlice(self, low: int, high: int, item_list: list[_VT]) -> None:
         """Set a value to a given index."""

--- a/src/einspect/structs/py_long.py
+++ b/src/einspect/structs/py_long.py
@@ -4,7 +4,7 @@ import ctypes
 from ctypes import Array, c_uint32
 
 from einspect.structs.deco import struct
-from einspect.structs.py_object import PyVarObject, Fields
+from einspect.structs.py_object import Fields, PyVarObject
 
 
 @struct
@@ -18,10 +18,7 @@ class PyLongObject(PyVarObject):
     _ob_digit_0: ctypes.c_uint32 * 0
 
     def _format_fields_(self) -> Fields:
-        return {
-            **super()._format_fields_(),
-            "ob_digit": "Array[c_uint32]"
-        }
+        return {**super()._format_fields_(), "ob_digit": "Array[c_uint32]"}
 
     @property
     def mem_size(self) -> int:

--- a/src/einspect/structs/py_long.py
+++ b/src/einspect/structs/py_long.py
@@ -50,9 +50,9 @@ class PyLongObject(PyVarObject):
 
     @property
     def value(self) -> int:
-        digit: int
         if self.ob_size == 0:
             return 0
+        digit: int
         val = sum(digit * 1 << (30 * i) for i, digit in enumerate(self.ob_digit))
         size: int = self.ob_size  # type: ignore
         return val * (-1 if size < 0 else 1)

--- a/src/einspect/structs/py_object.py
+++ b/src/einspect/structs/py_object.py
@@ -2,13 +2,12 @@
 from __future__ import annotations
 
 import ctypes
-from ctypes import pointer
-from ctypes import Structure, py_object, pythonapi
-from typing import Generic, List, Tuple, TypeVar, Type, Union, Dict
+from ctypes import Structure, pointer, py_object, pythonapi
+from typing import Dict, Generic, Tuple, Type, TypeVar, Union
 
 from typing_extensions import Self
 
-from einspect.compat import python_req, Version
+from einspect.compat import Version, python_req
 from einspect.protocols.delayed_bind import bind_api
 from einspect.structs.deco import struct
 
@@ -27,20 +26,8 @@ class PyObject(Structure, Generic[_T, _KT, _VT]):
     ob_refcnt: int
     ob_type: pointer[Self]
     # Need to use generics from typing to work for py-3.8
-    _fields_: List[Tuple[str, type]]
+    _fields_: list[tuple[str, type]]
     _from_type_name_: str
-
-    @bind_api(python_req(Version.PY_3_10) or ctypes.pythonapi["Py_NewRef"])
-    def NewRef(self) -> object:
-        """Returns new reference of the PyObject."""
-
-    @bind_api(ctypes.pythonapi["Py_IncRef"])
-    def IncRef(self) -> None:
-        """Increment the reference count of the PyObject."""
-
-    @bind_api(ctypes.pythonapi["Py_DecRef"])
-    def DecRef(self) -> None:
-        """Decrement the reference count of the PyObject."""
 
     @property
     def mem_size(self) -> int:
@@ -104,6 +91,26 @@ class PyObject(Structure, Generic[_T, _KT, _VT]):
         ptr = ctypes.pointer(self)
         obj = ctypes.cast(ptr, ctypes.py_object)
         return obj
+
+    @bind_api(python_req(Version.PY_3_10) or pythonapi["Py_NewRef"])
+    def NewRef(self) -> object:
+        """Returns new reference of the PyObject."""
+
+    @bind_api(pythonapi["Py_IncRef"])
+    def IncRef(self) -> None:
+        """Increment the reference count of the PyObject."""
+
+    @bind_api(pythonapi["Py_DecRef"])
+    def DecRef(self) -> None:
+        """Decrement the reference count of the PyObject."""
+
+    @bind_api(pythonapi["PyObject_GetAttr"])
+    def GetAttr(self, name: str) -> object:
+        """Return the attribute of the PyObject."""
+
+    @bind_api(pythonapi["PyObject_SetAttr"])
+    def SetAttr(self, name: str, value: object) -> int:
+        """Set the attribute of the PyObject."""
 
 
 @struct

--- a/src/einspect/structs/py_object.py
+++ b/src/einspect/structs/py_object.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import ctypes
 from ctypes import Structure, pointer, py_object, pythonapi
-from typing import Dict, Generic, Tuple, Type, TypeVar, Union
+from typing import Dict, Generic, List, Tuple, Type, TypeVar, Union
 
 from typing_extensions import Self
 
@@ -26,7 +26,7 @@ class PyObject(Structure, Generic[_T, _KT, _VT]):
     ob_refcnt: int
     ob_type: pointer[Self]
     # Need to use generics from typing to work for py-3.8
-    _fields_: list[tuple[str, type]]
+    _fields_: List[Tuple[str, type]]
     _from_type_name_: str
 
     @property

--- a/src/einspect/structs/py_object.py
+++ b/src/einspect/structs/py_object.py
@@ -10,6 +10,7 @@ from typing_extensions import Self
 from einspect.compat import Version, python_req
 from einspect.protocols.delayed_bind import bind_api
 from einspect.structs.deco import struct
+from einspect.types import ptr
 
 Fields = Dict[str, Union[str, Tuple[str, Type]]]
 
@@ -88,9 +89,11 @@ class PyObject(Structure, Generic[_T, _KT, _VT]):
 
     def into_object(self) -> py_object[_T]:
         """Cast the PyObject into a Python object."""
-        ptr = ctypes.pointer(self)
-        obj = ctypes.cast(ptr, ctypes.py_object)
-        return obj
+        return ctypes.cast(self.as_ref(), ctypes.py_object)
+
+    def as_ref(self) -> ptr[Self]:
+        """Return a pointer to the PyObject."""
+        return ctypes.pointer(self)
 
     @bind_api(python_req(Version.PY_3_10) or pythonapi["Py_NewRef"])
     def NewRef(self) -> object:

--- a/src/einspect/structs/py_set.py
+++ b/src/einspect/structs/py_set.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-from ctypes import Structure, POINTER, pointer, Array
-from typing import TypeVar, Generic
+from ctypes import POINTER, Array, Structure, pointer
+from typing import Generic, TypeVar
 
 from typing_extensions import Annotated
 
-from einspect.types import ptr
 from einspect.api import Py_hash_t
 from einspect.structs.deco import struct
 from einspect.structs.py_object import PyObject
+from einspect.types import ptr
 
 _T = TypeVar("_T")
 PySet_MINSIZE = 8
@@ -21,9 +21,11 @@ class SetEntry(Structure, Generic[_T]):
     hash: Annotated[int, Py_hash_t]
 
 
-@struct(fields=[
-    ("smalltable", SetEntry * PySet_MINSIZE),
-])
+@struct(
+    fields=[
+        ("smalltable", SetEntry * PySet_MINSIZE),
+    ]
+)
 class PySetObject(PyObject[set, None, _T]):
     """
     Defines a PySetObject Structure.
@@ -43,4 +45,3 @@ class PySetObject(PyObject[set, None, _T]):
     @classmethod
     def from_object(cls, obj: set[_T]) -> PySetObject[_T]:
         return cls.from_address(id(obj))
-

--- a/src/einspect/structs/py_set.py
+++ b/src/einspect/structs/py_set.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ctypes import POINTER, Array, Structure, pointer
+from ctypes import Array, Structure, pointer
 from typing import Generic, TypeVar
 
 from typing_extensions import Annotated
@@ -11,6 +11,7 @@ from einspect.structs.py_object import PyObject
 from einspect.types import ptr
 
 _T = TypeVar("_T")
+
 PySet_MINSIZE = 8
 """https://github.com/python/cpython/blob/3.11/Include/cpython/setobject.h#L18"""
 
@@ -18,7 +19,7 @@ PySet_MINSIZE = 8
 @struct
 class SetEntry(Structure, Generic[_T]):
     key: pointer[PyObject[_T, None, None]]
-    hash: Annotated[int, Py_hash_t]
+    hash: Annotated[int, Py_hash_t]  # noqa: A003
 
 
 @struct(
@@ -37,7 +38,7 @@ class PySetObject(PyObject[set, None, _T]):
     used: int  # Number active entries
     mask: int  # The table contains mask + 1 slots
     table: ptr[SetEntry[_T]]
-    hash: Annotated[int, Py_hash_t]
+    hash: Annotated[int, Py_hash_t]  # noqa: A003
     finger: int
     smalltable: Array[SetEntry[_T]]
     weakreflist: ptr[PyObject]

--- a/src/einspect/structs/py_tuple.py
+++ b/src/einspect/structs/py_tuple.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import ctypes
-from ctypes import pythonapi, pointer
-from typing import TypeVar, overload, Any, Tuple
+from ctypes import pointer, pythonapi
+from typing import Any, Tuple, TypeVar, overload
 
 from einspect.api import Py_ssize_t
 from einspect.protocols.delayed_bind import bind_api
@@ -26,24 +26,22 @@ class PyTupleObject(PyVarObject[tuple, None, _VT]):
 
     @classmethod
     def _format_fields_(cls) -> dict[str, str]:
-        return super()._format_fields_() | {
-            "ob_item": "*PyObject[]"
-        }
+        return super()._format_fields_() | {"ob_item": "*PyObject[]"}
 
     @overload
     @classmethod
-    def from_object(cls, obj: Tuple[_VT, ...]) -> PyTupleObject[_VT]:
+    def from_object(cls, obj: tuple[_VT, ...]) -> PyTupleObject[_VT]:
         ...
 
     @overload
     @classmethod
-    def from_object(cls, obj: Tuple[...]) -> PyTupleObject[Any]:
+    def from_object(cls, obj: tuple[...]) -> PyTupleObject[Any]:
         ...
 
     @classmethod
-    def from_object(cls, obj: Tuple[_VT, ...]) -> PyTupleObject[_VT]:
+    def from_object(cls, obj: tuple[_VT, ...]) -> PyTupleObject[_VT]:
         """Create a PyTupleObject from an object."""
-        return super(PyTupleObject, cls).from_object(obj)  # type: ignore
+        return super().from_object(obj)  # type: ignore
 
     @property
     def mem_size(self) -> int:

--- a/src/einspect/structs/py_tuple.py
+++ b/src/einspect/structs/py_tuple.py
@@ -26,7 +26,7 @@ class PyTupleObject(PyVarObject[tuple, None, _VT]):
     _ob_item_0: ptr[PyObject] * 0
 
     def _format_fields_(self) -> Fields:
-        return {**super()._format_fields_(), "ob_item": "*PyObject[]"}
+        return {**super()._format_fields_(), "ob_item": "Array[*PyObject]"}
 
     @overload
     @classmethod

--- a/src/einspect/structs/py_tuple.py
+++ b/src/einspect/structs/py_tuple.py
@@ -7,7 +7,8 @@ from typing import Any, TypeVar, overload
 from einspect.api import Py_ssize_t
 from einspect.protocols.delayed_bind import bind_api
 from einspect.structs.deco import struct
-from einspect.structs.py_object import PyObject, PyVarObject
+from einspect.structs.py_object import Fields, PyObject, PyVarObject
+from einspect.types import ptr
 
 _VT = TypeVar("_VT")
 
@@ -22,11 +23,10 @@ class PyTupleObject(PyVarObject[tuple, None, _VT]):
     """
 
     # Size of this array is only known after creation
-    _ob_item_0: Py_ssize_t * 0
+    _ob_item_0: ptr[PyObject] * 0
 
-    @classmethod
-    def _format_fields_(cls) -> dict[str, str]:
-        return super()._format_fields_() | {"ob_item": "*PyObject[]"}
+    def _format_fields_(self) -> Fields:
+        return {**super()._format_fields_(), "ob_item": "*PyObject[]"}
 
     @overload
     @classmethod

--- a/src/einspect/structs/py_tuple.py
+++ b/src/einspect/structs/py_tuple.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import ctypes
 from ctypes import pointer, pythonapi
-from typing import Any, Tuple, TypeVar, overload
+from typing import Any, TypeVar, overload
 
 from einspect.api import Py_ssize_t
 from einspect.protocols.delayed_bind import bind_api

--- a/src/einspect/structs/py_type.py
+++ b/src/einspect/structs/py_type.py
@@ -55,7 +55,7 @@ class PyTypeObject(PyVarObject[_T, None, None]):
     tp_setattro: setattrofunc
 
     # Functions to access object as input/output buffer
-    tp_as_buffer: c_void_p  # PyBufferProcs
+    tp_as_buffer: ptr[PyBufferProcs]
 
     # Flags to define presence of optional/expanded features
     tp_flags: Annotated[int, c_ulong]

--- a/src/einspect/structs/py_type.py
+++ b/src/einspect/structs/py_type.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from ctypes import (
+    CFUNCTYPE,
+    POINTER,
+    c_char,
+    c_char_p,
+    c_uint,
+    c_ulong,
+    c_void_p,
+    pointer,
+    pythonapi,
+)
+from typing import TypeVar
+
+from typing_extensions import Annotated, Self
+
+from einspect.protocols import bind_api
+from einspect.structs.deco import struct
+from einspect.structs.include.descrobject_h import PyGetSetDef, PyMemberDef
+from einspect.structs.include.methodobject_h import PyMethodDef
+from einspect.structs.include.object_h import *
+from einspect.structs.py_object import PyObject, PyVarObject
+from einspect.types import ptr
+
+__all__ = ("PyTypeObject",)
+
+_T = TypeVar("_T", bound=type)
+
+
+# noinspection PyPep8Naming
+@struct
+class PyTypeObject(PyVarObject[_T, None, None]):
+    """
+    Defines a PyTypeObject Structure.
+
+    https://github.com/python/cpython/blob/3.11/Doc/includes/typestruct.h
+    """
+
+    # const char *tp_name; /* For printing, in format "<module>.<name>" */
+    tp_name: c_char_p
+    # For allocation
+    tp_basicsize: int
+    tp_itemsize: int
+    # Methods to implement standard operations
+    tp_dealloc: CFUNCTYPE(None, POINTER(PyObject))
+    tp_vectorcall_offset: int
+    tp_getattr: getattrfunc
+    tp_setattr: setattrfunc
+    # formerly known as tp_compare (Python 2) or tp_reserved (Python 3)
+    tp_as_async: ptr[PyAsyncMethods]
+
+    tp_repr: reprfunc
+
+    # Method suites for standard classes
+    tp_as_number: ptr[PyNumberMethods]
+    tp_as_sequence: ptr[PySequenceMethods]
+    tp_as_mapping: ptr[PyMappingMethods]
+
+    # More standard operations (here for binary compatibility)
+    tp_hash: hashfunc
+    tp_call: ternaryfunc
+    tp_str: reprfunc
+    tp_getattro: getattrofunc
+    tp_setattro: setattrofunc
+
+    # Functions to access object as input/output buffer
+    tp_as_buffer: c_void_p  # PyBufferProcs
+
+    # Flags to define presence of optional/expanded features
+    tp_flags: Annotated[int, c_ulong]
+
+    tp_doc: c_char_p  # Documentation string
+
+    # Assigned meaning in release 2.0
+    # call function for all accessible objects
+    tp_traverse: traverseproc
+
+    tp_clear: inquiry  # delete references to contained objects
+
+    # Assigned meaning in release 2.1
+    # rich comparisons
+    tp_richcompare: richcmpfunc
+
+    tp_weaklistoffset: int  # weak reference enabler
+
+    # Iterators
+    tp_iter: getiterfunc
+    tp_iternext: iternextfunc
+
+    # Attribute descriptor and subclassing stuff
+    tp_methods: ptr[PyMethodDef]
+    tp_members: ptr[PyMemberDef]
+    tp_getset: ptr[PyGetSetDef]
+
+    # Strong reference on a heap type, borrowed reference on a static type
+    tp_base: pointer[Self]
+    tp_dict: ptr[PyObject]
+    tp_descr_get: descrgetfunc
+    tp_descr_set: descrsetfunc
+    tp_dict_offset: int
+    tp_init: initproc
+    tp_alloc: allocfunc
+    tp_new: newfunc
+    tp_free: freefunc  # Low-level free-memory routine
+    tp_is_gc: inquiry  # For PyObject_IS_GC
+    tp_bases: ptr[PyObject]
+    tp_mro: ptr[PyObject]  # method resolution order
+    tp_cache: ptr[PyObject]
+    tp_subclasses: c_void_p  # for static builtin types this is an index
+    tp_weaklist: ptr[PyObject]
+    tp_del: destructor
+
+    # Type attribute cache version tag. Added in version 2.6
+    tp_version_tag: Annotated[int, c_uint]
+
+    tp_finalize: destructor
+    tp_vectorcall: vectorcallfunc
+
+    # bitset of which type-watchers care about this type
+    tp_watched: c_char
+
+    @classmethod
+    def from_object(cls, obj: _T) -> PyTypeObject[_T]:
+        return super().from_object(obj)  # type: ignore
+
+    @bind_api(pythonapi["PyType_Modified"])
+    def Modified(self) -> None:
+        """Mark the type as modified."""

--- a/src/einspect/structs/py_type.py
+++ b/src/einspect/structs/py_type.py
@@ -1,16 +1,6 @@
 from __future__ import annotations
 
-from ctypes import (
-    CFUNCTYPE,
-    POINTER,
-    c_char,
-    c_char_p,
-    c_uint,
-    c_ulong,
-    c_void_p,
-    pointer,
-    pythonapi,
-)
+from ctypes import c_char, c_char_p, c_uint, c_ulong, c_void_p, pointer, pythonapi
 from typing import TypeVar
 
 from typing_extensions import Annotated, Self
@@ -43,7 +33,7 @@ class PyTypeObject(PyVarObject[_T, None, None]):
     tp_basicsize: int
     tp_itemsize: int
     # Methods to implement standard operations
-    tp_dealloc: CFUNCTYPE(None, POINTER(PyObject))
+    tp_dealloc: destructor
     tp_vectorcall_offset: int
     tp_getattr: getattrfunc
     tp_setattr: setattrfunc

--- a/src/einspect/structs/py_unicode.py
+++ b/src/einspect/structs/py_unicode.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import ctypes
-from ctypes import Array, POINTER, c_uint, c_int64
+from ctypes import POINTER, Array, c_int64, c_uint
 from enum import IntEnum
 
 from typing_extensions import Annotated

--- a/src/einspect/types.py
+++ b/src/einspect/types.py
@@ -31,7 +31,10 @@ class _Ptr(_Pointer):
         if isinstance(item, typing._GenericAlias):
             item = get_origin(item)
 
-        return ctypes.POINTER(item)
+        try:
+            return ctypes.POINTER(item)
+        except TypeError as e:
+            raise TypeError(f"{e} (During POINTER({item}))") from e
 
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/src/einspect/types.py
+++ b/src/einspect/types.py
@@ -1,8 +1,9 @@
 import ctypes
 import typing
+
 # noinspection PyUnresolvedReferences, PyProtectedMember
 from ctypes import _Pointer
-from typing import List, TypeVar, TYPE_CHECKING, get_origin, overload
+from typing import TYPE_CHECKING, List, TypeVar, get_origin, overload
 
 __all__ = ("ptr", "Array")
 
@@ -42,6 +43,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
         Resolves to ctypes.Array directly at runtime.
         """
+
         _length_ = 0
         _type_ = ctypes.c_void_p
 
@@ -56,11 +58,14 @@ if TYPE_CHECKING:  # pragma: no cover
         def __getitem__(self, item):
             raise NotImplementedError
 
+
 if not TYPE_CHECKING:
     # Runtime overrides
-    globals().update({
-        # Overwrite ctypes.pointer -> _Ptr
-        "ptr": _Ptr,
-        # Define Array as ctypes.Array
-        "Array": ctypes.Array,
-    })
+    globals().update(
+        {
+            # Overwrite ctypes.pointer -> _Ptr
+            "ptr": _Ptr,
+            # Define Array as ctypes.Array
+            "Array": ctypes.Array,
+        }
+    )

--- a/src/einspect/utils.py
+++ b/src/einspect/utils.py
@@ -11,7 +11,7 @@ def address(obj: Any) -> int:
     source = ctypes.py_object(obj)
     addr = ctypes.c_void_p.from_buffer(source).value
     if addr is None:
-        raise ValueError("address: NULL object")
+        raise ValueError("address: NULL object")  # pragma: no cover
     return addr
 
 

--- a/src/einspect/views/__init__.py
+++ b/src/einspect/views/__init__.py
@@ -1,5 +1,4 @@
-from einspect.views.view_base import View, VarView, AnyView
-from einspect.views.view_set import SetView
+from einspect.views.view_base import AnyView, VarView, View
 from einspect.views.view_bool import BoolView
 from einspect.views.view_dict import DictView
 from einspect.views.view_float import FloatView

--- a/src/einspect/views/__init__.py
+++ b/src/einspect/views/__init__.py
@@ -8,3 +8,18 @@ from einspect.views.view_mapping_proxy import MappingProxyView
 from einspect.views.view_set import SetView
 from einspect.views.view_str import StrView
 from einspect.views.view_tuple import TupleView
+
+__all__ = (
+    "AnyView",
+    "VarView",
+    "View",
+    "BoolView",
+    "DictView",
+    "FloatView",
+    "IntView",
+    "ListView",
+    "MappingProxyView",
+    "StrView",
+    "SetView",
+    "TupleView",
+)

--- a/src/einspect/views/_display.py
+++ b/src/einspect/views/_display.py
@@ -2,9 +2,7 @@
 from __future__ import annotations
 
 import ctypes
-
-# noinspection PyUnresolvedReferences, PyProtectedMember
-from ctypes import Array, _Pointer, pointer
+from ctypes import Array
 from string import Template
 from typing import TYPE_CHECKING, Any
 
@@ -34,7 +32,8 @@ def format_value(obj: Any, cast_to: type | None = None) -> str:
         res = list(map(format_value, obj))
         return f"[{', '.join(res)}]"
     # For pointers, get the value
-    if isinstance(obj, _Pointer):
+    # noinspection PyUnresolvedReferences, PyProtectedMember
+    if isinstance(obj, ctypes._Pointer):
         val = format_value(obj.contents) if obj else "NULL"
         wrap = f"[{val}]" if not (val.startswith("[") and val.endswith("]")) else val
         return f"&{wrap}"

--- a/src/einspect/views/_display.py
+++ b/src/einspect/views/_display.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import ctypes
+
 # noinspection PyUnresolvedReferences, PyProtectedMember
-from ctypes import pointer, _Pointer, Array
+from ctypes import Array, _Pointer, pointer
 from string import Template
 from typing import TYPE_CHECKING, Any
 
@@ -48,7 +49,9 @@ def format_value(obj: Any, cast_to: type | None = None) -> str:
         return repr(obj)
 
 
-def format_attr(struct: PyObject, attr: str, hint: str | tuple[str, type], types: bool) -> str:
+def format_attr(
+    struct: PyObject, attr: str, hint: str | tuple[str, type], types: bool
+) -> str:
     value = getattr(struct, attr)
     type_cast = None
     if isinstance(hint, tuple):
@@ -75,8 +78,6 @@ def format_display(v: View, types: bool = True) -> str:
 
     # Get attributes
     for attr, type_hint in struct._format_fields_().items():
-        lines.append(
-            indent(format_attr(struct, attr, type_hint, types))
-        )
+        lines.append(indent(format_attr(struct, attr, type_hint, types)))
 
     return "\n".join(lines)

--- a/src/einspect/views/factory.py
+++ b/src/einspect/views/factory.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 import warnings
 from types import MappingProxyType
-from typing import Final, Type, TypeVar, overload, Any
+from typing import Any, Final, Type, TypeVar, overload
 
-from einspect.views.view_base import View, REF_DEFAULT
+from einspect.views.view_base import REF_DEFAULT, View
 from einspect.views.view_bool import BoolView
 from einspect.views.view_dict import DictView
 from einspect.views.view_float import FloatView
@@ -18,7 +18,7 @@ from einspect.views.view_tuple import TupleView
 
 __all__ = ("view",)
 
-VIEW_TYPES: Final[dict[type, Type[View]]] = {
+VIEW_TYPES: Final[dict[type, type[View]]] = {
     object: View,
     int: IntView,
     bool: BoolView,

--- a/src/einspect/views/factory.py
+++ b/src/einspect/views/factory.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import warnings
 from types import MappingProxyType
-from typing import Any, Final, Type, TypeVar, overload
+from typing import Any, Final, TypeVar, overload
 
 from einspect.views.view_base import REF_DEFAULT, View
 from einspect.views.view_bool import BoolView

--- a/src/einspect/views/unsafe.py
+++ b/src/einspect/views/unsafe.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from contextlib import contextmanager
-from dataclasses import dataclass
 from functools import wraps
 from typing import TYPE_CHECKING, TypeVar
 

--- a/src/einspect/views/view_base.py
+++ b/src/einspect/views/view_base.py
@@ -95,7 +95,7 @@ class View(BaseView[_T, _KT, _VT]):
         self._pyobject.ob_refcnt = value
 
     @property
-    def type(self) -> type[_T]:
+    def type(self) -> Type[_T]:
         """Type of the object."""
         return self._pyobject.ob_type.contents.into_object().value  # type: ignore
 

--- a/src/einspect/views/view_base.py
+++ b/src/einspect/views/view_base.py
@@ -254,8 +254,8 @@ class VarView(View[_T, _KT, _VT]):
 
     @property
     def size(self) -> int:
-        """Size of the list."""
-        return int(self._pyobject.ob_size)  # type: ignore
+        """Size (ob_size) of the PyVarObject."""
+        return self._pyobject.ob_size
 
     @size.setter
     def size(self, value: int) -> None:

--- a/src/einspect/views/view_base.py
+++ b/src/einspect/views/view_base.py
@@ -8,11 +8,15 @@ from abc import ABC
 from contextlib import ExitStack
 from copy import deepcopy
 from ctypes import py_object, sizeof
-from typing import Generic, Type, TypeVar, get_type_hints, Final
+from typing import Final, Generic, Type, TypeVar, get_type_hints
 
 from einspect.api import Py, PyObj_FromPtr
-from einspect.errors import (DroppedReference, MovedError,
-                             UnsafeAttributeError, UnsafeError)
+from einspect.errors import (
+    DroppedReference,
+    MovedError,
+    UnsafeAttributeError,
+    UnsafeError,
+)
 from einspect.structs import PyObject, PyVarObject
 from einspect.views._display import format_display
 from einspect.views.unsafe import UnsafeContext, unsafe
@@ -42,12 +46,10 @@ class BaseView(ABC, Generic[_T, _KT, _VT], UnsafeContext):
     def __init__(self, obj: _T, ref: bool = REF_DEFAULT) -> None:
         super().__init__()
         # Stores base info for repr and errors
-        self._base_type: Type[_T] = type(obj)
+        self._base_type: type[_T] = type(obj)
         self._base_id = id(obj)
         # Get a reference if ref=True
-        self._base: py_object[_T] | None = (
-            _wrap_py_object(obj) if ref else None
-        )
+        self._base: py_object[_T] | None = _wrap_py_object(obj) if ref else None
         # Attempt to get a weakref
         try:
             self._base_weakref = weakref.ref(obj)
@@ -93,7 +95,7 @@ class View(BaseView[_T, _KT, _VT]):
         self._pyobject.ob_refcnt = value
 
     @property
-    def type(self) -> Type[_T]:
+    def type(self) -> type[_T]:
         """Type of the object."""
         return self._pyobject.ob_type.contents.into_object().value  # type: ignore
 
@@ -205,6 +207,7 @@ class View(BaseView[_T, _KT, _VT]):
     def move_from(self, other: _V) -> _V:
         """Moves data at other View to this View."""
         from einspect.views import factory
+
         # Store our repr
         self_repr = repr(self)
         # Store our current address

--- a/src/einspect/views/view_dict.py
+++ b/src/einspect/views/view_dict.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterator, MutableMapping
 from ctypes import Array
 from typing import TypeVar
 
@@ -25,7 +24,7 @@ class DictView(View[dict, _KT, _VT], abc.MutableMapping[_KT, _VT]):
     def __len__(self) -> int:
         return self.used
 
-    def __iter__(self) -> Iterator[_KT]:
+    def __iter__(self) -> abc.Iterator[_KT]:
         ...
 
     def __getitem__(self, key: _KT) -> _VT:

--- a/src/einspect/views/view_dict.py
+++ b/src/einspect/views/view_dict.py
@@ -8,7 +8,7 @@ from einspect.api import Py_ssize_t
 from einspect.compat import abc
 from einspect.structs.py_dict import PyDictObject
 from einspect.views.unsafe import unsafe
-from einspect.views.view_base import View, REF_DEFAULT
+from einspect.views.view_base import REF_DEFAULT, View
 
 __all__ = ("DictView",)
 

--- a/src/einspect/views/view_int.py
+++ b/src/einspect/views/view_int.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ctypes import Array, sizeof, c_uint32
+from ctypes import Array, c_uint32, sizeof
 from typing import Iterable, TypeVar
 
 from einspect.structs import PyLongObject

--- a/src/einspect/views/view_list.py
+++ b/src/einspect/views/view_list.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ctypes import Array, c_long
+from ctypes import Array
 from typing import TypeVar, overload
 
 from einspect.api import Py_ssize_t

--- a/src/einspect/views/view_list.py
+++ b/src/einspect/views/view_list.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from ctypes import Array, c_long
 from typing import TypeVar, overload
 
-from einspect.compat import abc
 from einspect.api import Py_ssize_t
+from einspect.compat import abc
 from einspect.errors import UnsafeAttributeError
 from einspect.structs import PyListObject
-from einspect.views.view_base import VarView, REF_DEFAULT
+from einspect.views.view_base import REF_DEFAULT, VarView
 
 __all__ = ("ListView",)
 

--- a/src/einspect/views/view_mapping_proxy.py
+++ b/src/einspect/views/view_mapping_proxy.py
@@ -27,7 +27,7 @@ class MappingProxyView(View[MappingProxyType, _KT, _VT], abc.MutableMapping[_KT,
     def __len__(self) -> int:
         return dict.__len__(self.mapping)
 
-    def __iter__(self) -> Iterator[_KT]:
+    def __iter__(self) -> abc.Iterator[_KT]:
         return dict.__iter__(self.mapping)
 
     def __getitem__(self, __k: _KT) -> _VT:

--- a/src/einspect/views/view_mapping_proxy.py
+++ b/src/einspect/views/view_mapping_proxy.py
@@ -8,7 +8,7 @@ from einspect.compat import abc
 from einspect.structs import PyDictObject
 from einspect.structs.mapping_proxy import MappingProxyObject
 from einspect.views.unsafe import unsafe
-from einspect.views.view_base import View, REF_DEFAULT
+from einspect.views.view_base import REF_DEFAULT, View
 
 __all__ = ("MappingProxyView",)
 

--- a/src/einspect/views/view_set.py
+++ b/src/einspect/views/view_set.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from ctypes import cast, POINTER
+from ctypes import POINTER, cast
 from typing import TypeVar
 
 from einspect.structs import PyObject
-from einspect.types import Array, ptr
 from einspect.structs.py_set import PySetObject, SetEntry
+from einspect.types import Array, ptr
 from einspect.views.unsafe import unsafe
-from einspect.views.view_base import View, REF_DEFAULT
+from einspect.views.view_base import REF_DEFAULT, View
 
 __all__ = ("SetView",)
 
@@ -82,4 +82,3 @@ class SetView(View[set, None, _T]):
     @unsafe
     def weakreflist(self, value: ptr[PyObject]) -> None:
         self._pyobject.weakreflist = value
-

--- a/src/einspect/views/view_tuple.py
+++ b/src/einspect/views/view_tuple.py
@@ -7,7 +7,7 @@ from typing import Sequence, TypeVar, overload
 from einspect.api import Py_ssize_t
 from einspect.compat import abc
 from einspect.errors import UnsafeIndexError
-from einspect.structs import PyTupleObject
+from einspect.structs import PyObject, PyTupleObject
 from einspect.utils import new_ref
 from einspect.views.unsafe import unsafe
 from einspect.views.view_base import VarView
@@ -50,9 +50,8 @@ class TupleView(VarView[tuple, None, _VT], abc.Sequence):
         if isinstance(index, slice):
             raise ValueError("Cannot set slice of tuple")
         try:
-            ref = new_ref(value)
-            arr = self.item
-            arr[index] = ref
+            ref = PyObject.from_object(value).as_ref()
+            self.item[index] = ref
         except IndexError as err:
             if not self._unsafe:
                 raise UnsafeIndexError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ class Unbuffered:
 
 def _run(func_path: Path, name: str):
     import importlib
+
     rel_path = func_path.relative_to(TESTS_DIR)
     module_name = "tests." + ".".join(rel_path.with_suffix("").parts)
     module = importlib.import_module(module_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,13 @@ class Unbuffered:
 
 def _run(func_path: Path, name: str):
     import importlib
+    import os
+
+    import coverage
+
+    # Need these for coverage.py to work
+    os.putenv("COVERAGE_PROCESS_START", "1")
+    coverage.process_startup()
 
     rel_path = func_path.relative_to(TESTS_DIR)
     module_name = "tests." + ".".join(rel_path.with_suffix("").parts)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,13 +25,16 @@ class Unbuffered:
 
 def _run(func_path: Path, name: str):
     import importlib
-    import os
+    from contextlib import suppress
 
-    import coverage
+    # Optional subprocess coverage config
+    with suppress(ImportError):
+        import os
 
-    # Need these for coverage.py to work
-    os.putenv("COVERAGE_PROCESS_START", "1")
-    coverage.process_startup()
+        import coverage
+
+        os.putenv("COVERAGE_PROCESS_START", "1")
+        coverage.process_startup()
 
     rel_path = func_path.relative_to(TESTS_DIR)
     module_name = "tests." + ".".join(rel_path.with_suffix("").parts)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,7 @@ import sys
 from ctypes import pythonapi
 
 from einspect.api import Py
-from einspect.compat import Version, RequiresPythonVersion
+from einspect.compat import RequiresPythonVersion, Version
 from tests import get_addr
 
 
@@ -14,4 +14,3 @@ def test_compat_new_ref() -> None:
         assert get_addr(Py.NewRef) == get_addr(pythonapi["Py_NewRef"])
     else:
         assert Py.NewRef == RequiresPythonVersion(Version.PY_3_10)
-

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from einspect.compat import Version, python_req, RequiresPythonVersion
+from einspect.compat import RequiresPythonVersion, Version, python_req
 
 
 # Patch our python version to be 3.9

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -26,7 +26,9 @@ def pkg_class(pkg: ModuleType):
 
 @pytest.mark.parametrize(
     "mod_name",
-    filter(lambda x: x.startswith("view_") and not x.endswith("_base"), pkg_names(views))
+    filter(
+        lambda x: x.startswith("view_") and not x.endswith("_base"), pkg_names(views)
+    ),
 )
 def test_views_modules(mod_name: str):
     """Test that factory supports all views."""

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -3,6 +3,10 @@ import pytest
 from einspect import structs as st
 
 
+class UserClass:
+    pass
+
+
 class TestPyObject:
     def test_new(self):
         py_object = st.PyObject()
@@ -14,17 +18,32 @@ class TestPyObject:
         assert py_object.ob_refcnt == 1
         assert py_object.ob_type.contents.into_object().value == list
 
-    @pytest.mark.parametrize(["obj", "ob_type"], [
-        ("hello", str),
-        (1, int),
-        (1.0, float),
-        (True, bool),
-        (None, type(None)),
-    ])
+    @pytest.mark.parametrize(
+        ["obj", "ob_type"],
+        [
+            ("hello", str),
+            (1, int),
+            (1.0, float),
+            (True, bool),
+            (None, type(None)),
+        ],
+    )
     def test_obj(self, obj, ob_type):
         py_object = st.PyObject.from_object(obj)
         assert py_object.ob_refcnt >= 1
         assert py_object.ob_type.contents.into_object().value == ob_type
+
+    def test_api_setattr(self):
+        obj = UserClass()
+        py_object = st.PyObject.from_object(obj)
+        py_object.SetAttr("hello", 123)
+        assert getattr(obj, "hello") == 123
+
+    def test_api_getattr(self):
+        obj = UserClass()
+        py_object = st.PyObject.from_object(obj)
+        obj.xy = "test"
+        assert py_object.GetAttr("xy") == "test"
 
 
 class TestPyListObject:
@@ -36,13 +55,16 @@ class TestPyListObject:
         assert ls == [1, 2]
 
 
-@pytest.mark.parametrize(["obj", "struct", "size"], [
-    (False, st.PyBoolObject, (3 * 8)),
-    (True, st.PyBoolObject, (3 * 8) + 4),
-    (0, st.PyLongObject, (3 * 8)),
-    (50, st.PyLongObject, (3 * 8) + 4),
-    ((1, 2), st.PyTupleObject, (3 * 8) + (2 * 8)),
-])
+@pytest.mark.parametrize(
+    ["obj", "struct", "size"],
+    [
+        (False, st.PyBoolObject, (3 * 8)),
+        (True, st.PyBoolObject, (3 * 8) + 4),
+        (0, st.PyLongObject, (3 * 8)),
+        (50, st.PyLongObject, (3 * 8) + 4),
+        ((1, 2), st.PyTupleObject, (3 * 8) + (2 * 8)),
+    ],
+)
 def test_mem_size_sizeof(obj, struct, size):
     """Test for structs matching __sizeof__."""
     py_object = struct.from_object(obj)
@@ -50,11 +72,14 @@ def test_mem_size_sizeof(obj, struct, size):
     assert py_object.mem_size == size
 
 
-@pytest.mark.parametrize(["obj", "struct", "delta"], [
-    ([1, 2], st.PyListObject, lambda s: s.allocated * 8),
-    ([1, 2, 3], st.PyListObject, lambda s: s.allocated * 8),
-    # ({"A": 1, "B": 2}, st.PyDictObject, 0),
-])
+@pytest.mark.parametrize(
+    ["obj", "struct", "delta"],
+    [
+        ([1, 2], st.PyListObject, lambda s: s.allocated * 8),
+        ([1, 2, 3], st.PyListObject, lambda s: s.allocated * 8),
+        # ({"A": 1, "B": 2}, st.PyDictObject, 0),
+    ],
+)
 def test_mem_size_basic(obj, struct, delta):
     """
     Test for structs not matching __sizeof__.

--- a/tests/test_unsafe.py
+++ b/tests/test_unsafe.py
@@ -1,8 +1,9 @@
 """Test unsafe context and operations."""
+from ctypes import POINTER, c_int, pointer
+
 import pytest
 
-from einspect import view, errors
-from ctypes import pointer, POINTER, c_int
+from einspect import errors, view
 
 
 def test_unsafe_error():

--- a/tests/views/test_display.py
+++ b/tests/views/test_display.py
@@ -1,4 +1,5 @@
 from textwrap import dedent
+
 from einspect import view
 
 
@@ -7,12 +8,14 @@ def inline(s: str):
 
 
 def test_info_int():
-    x = 2 ** 32
+    x = 2**32
     info = view(x).info()
-    assert info == inline(f"""
+    assert info == inline(
+        f"""
     PyLongObject (at {hex(id(x))}):
        ob_refcnt: Py_ssize_t = 3
        ob_type: *PyTypeObject = &[int]
        ob_size: Py_ssize_t = 2
        ob_digit: Array[c_uint32] = [0, 4]
-    """)
+    """
+    )

--- a/tests/views/test_move.py
+++ b/tests/views/test_move.py
@@ -1,0 +1,24 @@
+"""Test moving of views."""
+from ast import literal_eval
+
+import pytest
+
+from einspect import view
+
+
+def test_move_op():
+    x = literal_eval("1593020931")
+    v = view(x)
+    with v.unsafe():
+        v <<= 5
+    assert x == 5
+    assert id(x) != id(5)
+
+
+def test_move_from():
+    x = literal_eval("2905504286")
+    v = view(x)
+    with v.unsafe():
+        v.move_from(view(5))
+    assert x == 5
+    assert id(x) != id(5)

--- a/tests/views/test_view_base.py
+++ b/tests/views/test_view_base.py
@@ -2,7 +2,7 @@ import ctypes
 
 import pytest
 
-from einspect import structs, errors, view
+from einspect import errors, structs, view
 from einspect.views.view_base import View
 
 
@@ -68,5 +68,3 @@ class TestView:
         v.drop()
         with pytest.raises(errors.DroppedReferenceError):
             _ = v.base.value
-
-

--- a/tests/views/test_view_base.py
+++ b/tests/views/test_view_base.py
@@ -3,32 +3,59 @@ import ctypes
 import pytest
 
 from einspect import errors, structs, view
-from einspect.views.view_base import View
+from einspect.views.view_base import VarView, View
 
 
 class TestView:
+    view_type = View
+    obj_type = object
+
+    def get_obj(self):
+        return self.obj_type()
+
+    def check_ref(self, a, b):
+        # Check ref count unless we're an instance of int or singletons
+        if self.obj_type in (int, bool, type(None)):
+            return
+        assert a == b
+
     def test_type(self):
-        obj = object()
-        v = view(obj)
+        obj = self.get_obj()
+        v = self.view_type(obj)
         assert isinstance(v, View)
         assert isinstance(v._pyobject, structs.PyObject)
+        assert v.type == type(obj)
+
+    def test_factory(self):
+        """Test factory."""
+        obj = self.get_obj()
+        v = view(obj)  # type: ignore
+        assert type(v) is self.view_type
+
+    def test_size(self):
+        # For sized test subclasses
+        obj = self.get_obj()
+        v = self.view_type(obj)
+        st = v._pyobject
+        if hasattr(st, "ob_size") or issubclass(self.view_type, VarView):
+            assert v.size == st.ob_size  # type: ignore
 
     def test_ref(self):
-        obj = object()
-        v = View(obj, ref=True)
+        obj = self.get_obj()
+        v = self.view_type(obj, ref=True)
         # Should be 2 references,
         # 1. "obj", 2. "v" (with ref=True)
-        assert v.ref_count == 2
+        self.check_ref(v.ref_count, 2)
 
     def test_no_ref(self):
-        obj = object()
-        v = View(obj, ref=False)
-        assert v.ref_count == 1
+        obj = self.get_obj()
+        v = self.view_type(obj, ref=False)
+        self.check_ref(v.ref_count, 1)
 
     def test_base_ref(self):
         """Access base with reference."""
-        obj = object()
-        v = View(obj, ref=True)
+        obj = self.get_obj()
+        v = self.view_type(obj, ref=True)
         assert isinstance(v.base, ctypes.py_object)
         assert v.base.value is obj
 
@@ -39,31 +66,39 @@ class TestView:
             pass
 
         obj = A()
-        v = View(obj, ref=False)
+        v = self.view_type(obj, ref=False)
         del obj
         with pytest.raises(errors.MovedError):
             _ = v.base
 
     def test_base_no_ref(self):
         """Access base with no ref should require unsafe."""
-        obj = object()
-        v = View(obj, ref=False)
-        with pytest.raises(errors.UnsafeError):
-            _ = v.base
+        obj = self.get_obj()
+        v = self.view_type(obj, ref=False)
+        # Normal case (no weakref support)
+        if self.obj_type.__weakrefoffset__ == 0:
+            with pytest.raises(errors.UnsafeError):
+                assert not v.base
+        # Alternate if supports weakref
+        else:
+            # Check weakref exists
+            assert v._base_weakref is not None
+            assert v._base_weakref() is obj
+            assert v.base.value is obj
 
     def test_base_unsafe(self):
         """Access base with unsafe."""
-        obj = object()
-        v = View(obj, ref=False)
-        assert v.ref_count == 1
+        obj = self.get_obj()
+        v = self.view_type(obj, ref=False)
+        self.check_ref(v.ref_count, 1)
 
         with v.unsafe():
             assert v.base.value is obj
 
     def test_drop(self):
         """Test accessing after drop."""
-        obj = object()
-        v = View(obj, ref=True)
+        obj = self.get_obj()
+        v = self.view_type(obj, ref=True)
         assert v.base.value is obj
         v.drop()
         with pytest.raises(errors.DroppedReferenceError):

--- a/tests/views/test_view_dict.py
+++ b/tests/views/test_view_dict.py
@@ -7,17 +7,17 @@ from einspect.views.view_dict import DictView
 
 @pytest.fixture(scope="function")
 def obj():
-    return {
-        "test": 1,
-        2: 2.0
-    }
+    return {"test": 1, 2: 2.0}
 
 
 class TestDictView:
-    @pytest.mark.parametrize(["factory"], [
-        (view,),
-        (DictView,),
-    ])
+    @pytest.mark.parametrize(
+        ["factory"],
+        [
+            (view,),
+            (DictView,),
+        ],
+    )
     def test_factory(self, obj, factory):
         """Test different ways of creating a ListView."""
         v = factory(obj)

--- a/tests/views/test_view_int.py
+++ b/tests/views/test_view_int.py
@@ -1,18 +1,21 @@
 import pytest
 
 from einspect import view
-from einspect.views.view_int import IntView
 from einspect.structs import PyLongObject
+from einspect.views.view_int import IntView
 
 
 class TestIntView:
-    @pytest.mark.parametrize(["obj", "size"], [
-        (1, 1),
-        (2 ** 8, 1),
-        (0, 0),  # CPython detail where 0 has ob_size of 0
-        (-1, -1),
-        (-9000, -1),
-    ])
+    @pytest.mark.parametrize(
+        ["obj", "size"],
+        [
+            (1, 1),
+            (2**8, 1),
+            (0, 0),  # CPython detail where 0 has ob_size of 0
+            (-1, -1),
+            (-9000, -1),
+        ],
+    )
     def test_factory(self, obj, size):
         v = view(obj)
         assert isinstance(v, IntView)

--- a/tests/views/test_view_int.py
+++ b/tests/views/test_view_int.py
@@ -1,25 +1,49 @@
+import ctypes
+
 import pytest
 
-from einspect import view
-from einspect.structs import PyLongObject
+from einspect.views import BoolView
 from einspect.views.view_int import IntView
+from tests.views.test_view_base import TestView
 
 
-class TestIntView:
-    @pytest.mark.parametrize(
-        ["obj", "size"],
-        [
-            (1, 1),
-            (2**8, 1),
-            (0, 0),  # CPython detail where 0 has ob_size of 0
-            (-1, -1),
-            (-9000, -1),
-        ],
-    )
-    def test_factory(self, obj, size):
-        v = view(obj)
-        assert isinstance(v, IntView)
-        assert isinstance(v._pyobject, PyLongObject)
-        assert v.type == int
-        assert v.size == size
+class TestIntView(TestView):
+    view_type = IntView
+    obj_type = int
+
+    def get_obj(self):
+        return 2**128 + 5
+
+    def test_digits(self):
+        obj = self.get_obj()
+        v = self.view_type(obj)
+        assert isinstance(v.digits, ctypes.Array)
+        assert isinstance(v.digits[0], int)
+
+    def test_value(self):
+        obj = self.get_obj()
+        v = self.view_type(obj)
         assert v.value == obj
+
+
+class TestBoolView(TestIntView):
+    view_type = BoolView
+    obj_type = bool
+
+    def get_obj(self):
+        return False
+
+    def test_memsize(self):
+        v = self.view_type(True)
+        expect_size = True.__sizeof__()
+        assert v.mem_size == expect_size
+
+    def test_singleton_true(self):
+        v = self.view_type(True)
+        assert v.size == 1
+        assert v.digits[0] == 1
+
+    def test_singleton_false(self):
+        v = self.view_type(False)
+        assert v.size == 0
+        assert v.digits[0] == 0

--- a/tests/views/test_view_list.py
+++ b/tests/views/test_view_list.py
@@ -13,10 +13,13 @@ def obj() -> list[int]:
 
 
 class TestListView:
-    @pytest.mark.parametrize(["factory"], [
-        (view,),
-        (ListView,),
-    ])
+    @pytest.mark.parametrize(
+        ["factory"],
+        [
+            (view,),
+            (ListView,),
+        ],
+    )
     def test_factory(self, obj, factory):
         """Test different ways of creating a ListView."""
         v = factory(obj)

--- a/tests/views/test_view_list.py
+++ b/tests/views/test_view_list.py
@@ -5,41 +5,29 @@ import pytest
 from einspect.structs import PyListObject
 from einspect.views.factory import view
 from einspect.views.view_list import ListView
+from tests.views.test_view_base import TestView
 
 
-@pytest.fixture(scope="function")
-def obj() -> list[int]:
-    return [1, 2, 3]
+class TestListView(TestView):
+    view_type = ListView
+    obj_type = list
 
-
-class TestListView:
-    @pytest.mark.parametrize(
-        ["factory"],
-        [
-            (view,),
-            (ListView,),
-        ],
-    )
-    def test_factory(self, obj, factory):
-        """Test different ways of creating a ListView."""
-        v = factory(obj)
-        assert isinstance(v, ListView)
-        assert isinstance(v._pyobject, PyListObject)
-        assert v.size == len(obj)
-        assert v.type == list
-        assert ~v is obj
+    def get_obj(self):
+        return [400, 500, 600]
 
     def test_sized(self):
-        ls = [1, 2]
-        v = view(ls)
-        assert len(v) == 2
-        ls.pop()
-        assert len(v) == 1
-        ls.clear()
+        obj = self.get_obj()
+        orig_len = len(obj)
+        v = self.view_type(obj)
+        assert len(v) == orig_len
+        obj.pop()
+        assert len(v) == orig_len - 1
+        obj.clear()
         assert len(v) == 0
 
-    def test_getitem(self, obj):
-        v = view(obj)
+    def test_getitem(self):
+        obj = self.get_obj()
+        v = self.view_type(obj)
         assert v[0] == obj[0]
         assert v[1] == obj[1]
         assert v[2] == obj[2]
@@ -47,12 +35,12 @@ class TestListView:
         assert v[:] == obj[:]
 
     def test_setitem(self):
-        ls = [1, 2, 3]
-        v = view(ls)
+        obj = [1, 2, 3]
+        v = self.view_type(obj)
         v[0] = 10
         v[1] = 20
-        assert ls == [10, 20, 3]
+        assert obj == [10, 20, 3]
         v[1:] = ["hi", "abc"]
-        assert ls == [10, "hi", "abc"]
+        assert obj == [10, "hi", "abc"]
         v[:] = ("A", "B")
-        assert ls == ["A", "B"]
+        assert obj == ["A", "B"]

--- a/tests/views/test_view_mapping_proxy.py
+++ b/tests/views/test_view_mapping_proxy.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import pytest
-
 from types import MappingProxyType
 
+import pytest
+
+from einspect.structs import MappingProxyObject
 from einspect.views.factory import view
 from einspect.views.view_mapping_proxy import MappingProxyView
-from einspect.structs import MappingProxyObject
 
 
 @pytest.fixture(scope="function")
@@ -16,10 +16,13 @@ def obj() -> MappingProxyType[str, int]:
 
 
 class TestTupleView:
-    @pytest.mark.parametrize(["factory"], [
-        (view,),
-        (MappingProxyView,),
-    ])
+    @pytest.mark.parametrize(
+        ["factory"],
+        [
+            (view,),
+            (MappingProxyView,),
+        ],
+    )
     def test_factory(self, obj, factory):
         """Test different ways of creating a ListView."""
         v = factory(obj)

--- a/tests/views/test_view_set.py
+++ b/tests/views/test_view_set.py
@@ -13,10 +13,13 @@ def obj() -> set[int]:
 
 
 class TestSetView:
-    @pytest.mark.parametrize(["factory"], [
-        (view,),
-        (SetView,),
-    ])
+    @pytest.mark.parametrize(
+        ["factory"],
+        [
+            (view,),
+            (SetView,),
+        ],
+    )
     def test_factory(self, obj, factory):
         v = factory(obj)
         assert isinstance(v, SetView)

--- a/tests/views/test_view_set.py
+++ b/tests/views/test_view_set.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import pytest
 
-from einspect.structs import PySetObject
-from einspect.views.factory import view
 from einspect.views.view_set import SetView
+from tests.views.test_view_base import TestView
 
 
 @pytest.fixture(scope="function")
@@ -12,19 +11,19 @@ def obj() -> set[int]:
     return {1, 2, 3}
 
 
-class TestSetView:
-    @pytest.mark.parametrize(
-        ["factory"],
-        [
-            (view,),
-            (SetView,),
-        ],
-    )
-    def test_factory(self, obj, factory):
-        v = factory(obj)
-        assert isinstance(v, SetView)
-        assert isinstance(v._pyobject, PySetObject)
-        assert v.type == set
-        assert v.used == len(obj)
-        assert v.base.value is obj
-        assert ~v is obj
+class TestSetView(TestView):
+    view_type = SetView
+    obj_type = set
+
+    def get_obj(self) -> set[int]:
+        return {1, 2, 3}
+
+    def test_sized(self):
+        obj = self.get_obj()
+        orig_len = len(obj)
+        v = self.view_type(obj)
+        assert len(v) == orig_len
+        obj.pop()
+        assert len(v) == orig_len - 1
+        obj.clear()
+        assert len(v) == 0

--- a/tests/views/test_view_str.py
+++ b/tests/views/test_view_str.py
@@ -1,7 +1,7 @@
 import pytest
 
-from einspect import view, structs
-from einspect.structs.py_unicode import State, Kind
+from einspect import structs, view
+from einspect.structs.py_unicode import Kind, State
 from einspect.views.view_str import StrView
 
 TEXT = "2fe7b604-9664-41e6-9af0-9b472864bfc8"

--- a/tests/views/test_view_tuple.py
+++ b/tests/views/test_view_tuple.py
@@ -16,10 +16,13 @@ def obj() -> tuple[int, int, int]:
 
 
 class TestTupleView:
-    @pytest.mark.parametrize(["factory"], [
-        (view,),
-        (TupleView,),
-    ])
+    @pytest.mark.parametrize(
+        ["factory"],
+        [
+            (view,),
+            (TupleView,),
+        ],
+    )
     def test_factory(self, obj, factory):
         """Test different ways of creating a ListView."""
         v = factory(obj)


### PR DESCRIPTION
Added:
- `structs/include` submodule with various defined structs
- `PyTypeObject` structure

Fixes:
- Improve 3.8 compatibility with runtime type hint inspections
- Upgrade PyTupleObject to use new ptr[PyObject] field instead of previous Py_ssize_t unmanaged address pointer