### PR TITLE
Correct PyListObject display to use ob_size instead of allocated

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Run Tests
       run: |
-        poetry run pytest --cov=./src --cov-report=xml
+        poetry run pytest --cov=./src --cov-report=term --cov-report=xml
 
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v3.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.3.0"
+    rev: "v4.4.0"
     hooks:
       - id: check-json
       - id: check-toml
@@ -10,7 +10,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.11.4
     hooks:
       - id: isort
         name: isort (python)
@@ -18,12 +18,12 @@ repos:
         exclude: einspect/structs/__init__.py
 
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 22.12.0
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
         additional_dependencies: [flake8-builtins]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "einspect"
-version = "0.4.0a1"
+version = "0.4.0a2"
 description = "Extended Inspect - view and modify memory structs of runtime objects."
 authors = ["ionite34 <dev@ionite.io>"]
 license = "MIT"

--- a/src/einspect/structs/py_list.py
+++ b/src/einspect/structs/py_list.py
@@ -32,7 +32,7 @@ class PyListObject(PyVarObject[list, None, _VT]):
     def _format_fields_(self) -> Fields:
         return {
             **super()._format_fields_(),
-            "ob_item": ("**PyObject", ptr[ptr[PyObject] * self.allocated]),
+            "ob_item": ("**PyObject", ptr[ptr[PyObject] * self.ob_size]),
             "allocated": "c_long",
         }
 

--- a/src/einspect/views/_display.py
+++ b/src/einspect/views/_display.py
@@ -21,16 +21,27 @@ DISP_TRANSFORMS = {
 }
 
 
-def format_value(obj: Any, cast_to: type | None = None) -> str:
-    """Format a value."""
+def format_value(
+    obj: Any, cast_to: type | None = None, arr_bound: int | None = None
+) -> str:
+    """
+    Format a value.
+
+    Args:
+        obj: The value to format
+        cast_to: The type to cast the value to
+        arr_bound: The max number of pointers to dereference for Array[PyObject] types
+    """
     # Cast if needed
     if cast_to is not None:
         obj = ctypes.cast(obj, cast_to)  # type: ignore
         return format_value(obj)
     # Array: format as list
     if isinstance(obj, Array):
-        res = list(map(format_value, obj))
-        return f"[{', '.join(res)}]"
+        # Only get elements up to arr_bound
+        res = list(map(format_value, obj[:arr_bound]))
+        diff = len(obj) - len(res)
+        return f"[{', '.join(res)}{', ...' if diff > 0 else ''}]"
     # For pointers, get the value
     # noinspection PyUnresolvedReferences, PyProtectedMember
     if isinstance(obj, ctypes._Pointer):

--- a/tests/views/test_display.py
+++ b/tests/views/test_display.py
@@ -12,10 +12,25 @@ def test_info_int():
     info = view(x).info()
     assert info == inline(
         f"""
-    PyLongObject (at {hex(id(x))}):
-       ob_refcnt: Py_ssize_t = 3
-       ob_type: *PyTypeObject = &[int]
-       ob_size: Py_ssize_t = 2
-       ob_digit: Array[c_uint32] = [0, 4]
-    """
+        PyLongObject (at {hex(id(x))}):
+           ob_refcnt: Py_ssize_t = 3
+           ob_type: *PyTypeObject = &[int]
+           ob_size: Py_ssize_t = 2
+           ob_digit: Array[c_uint32] = [0, 4]
+        """
+    )
+
+
+def test_info_list():
+    x = [1, "A"]
+    info = view(x).info()
+    assert info == inline(
+        f"""
+        PyListObject (at {hex(id(x))}):
+           ob_refcnt: Py_ssize_t = 2
+           ob_type: *PyTypeObject = &[list]
+           ob_size: Py_ssize_t = 2
+           ob_item: **PyObject = &[&[1], &['A']]
+           allocated: c_long = 2
+        """
     )


### PR DESCRIPTION
## Fixes
- Since pointers beyond `ob_size` may not reference valid python objects, only render up to `ob_size` items instead of `allocated`
- Version bump to v0.4.0a2