### PR TITLE
Fixes for View.base return type and bind_api base class resolution

### DIFF
--- a/docs/source/api/views/index.md
+++ b/docs/source/api/views/index.md
@@ -12,4 +12,5 @@ view_list
 view_mapping_proxy
 view_str
 view_tuple
+view_type
 ```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
 project = "einspect"
 copyright = "2023, Ionite"
 author = "Ionite"
-release = "v0.4.0"
+release = "v0.4.1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "einspect"
-version = "0.4.0"
+version = "0.4.1"
 description = "Extended Inspect - view and modify memory structs of runtime objects."
 authors = ["ionite34 <dev@ionite.io>"]
 license = "MIT"

--- a/src/einspect/structs/py_dict.py
+++ b/src/einspect/structs/py_dict.py
@@ -4,7 +4,6 @@ from ctypes import (
     POINTER,
     Structure,
     c_char,
-    c_ssize_t,
     c_uint8,
     c_uint32,
     c_uint64,
@@ -13,12 +12,16 @@ from ctypes import (
 )
 from typing import Dict, TypeVar
 
+from typing_extensions import Annotated
+
 from einspect.api import Py_ssize_t
 from einspect.protocols.delayed_bind import bind_api
 from einspect.structs.deco import struct
 from einspect.structs.py_object import PyObject
+from einspect.types import ptr
 
 __all__ = ("PyDictObject",)
+
 
 _KT = TypeVar("_KT")
 _VT = TypeVar("_VT")
@@ -52,10 +55,10 @@ class PyDictObject(PyObject[dict, _KT, _VT]):
     """
 
     # Number of items in the dictionary
-    ma_used: c_ssize_t
+    ma_used: int
     # Dictionary version: globally unique, changes on modification
-    ma_version_tag: c_uint64
-    ma_keys: POINTER(DictKeysObject)
+    ma_version_tag: Annotated[int, c_uint64]
+    ma_keys: ptr[DictKeysObject]
     # If ma_values is NULL, the table is "combined": keys and values
     # are stored in ma_keys. Otherwise, keys are stored in ma_keys
     # and values are stored in ma_values

--- a/src/einspect/structs/py_long.py
+++ b/src/einspect/structs/py_long.py
@@ -8,7 +8,7 @@ from einspect.structs.py_object import Fields, PyVarObject
 
 
 @struct
-class PyLongObject(PyVarObject):
+class PyLongObject(PyVarObject[int, None, None]):
     """
     Defines a PyLongObject Structure.
 

--- a/src/einspect/structs/py_object.py
+++ b/src/einspect/structs/py_object.py
@@ -2,15 +2,18 @@
 from __future__ import annotations
 
 import ctypes
-from ctypes import Structure, pythonapi
-from typing import Dict, Generic, List, Tuple, Type, TypeVar, Union
+from ctypes import Structure, c_void_p, pythonapi
+from typing import TYPE_CHECKING, Dict, Generic, List, Tuple, Type, TypeVar, Union
 
-from typing_extensions import Self
+from typing_extensions import Annotated, Self
 
 from einspect.compat import Version, python_req
 from einspect.protocols.delayed_bind import bind_api
 from einspect.structs.deco import struct
 from einspect.types import ptr
+
+if TYPE_CHECKING:
+    from einspect.structs import PyTypeObject
 
 Fields = Dict[str, Union[str, Tuple[str, Type]]]
 
@@ -19,14 +22,12 @@ _KT = TypeVar("_KT")
 _VT = TypeVar("_VT")
 
 
-# noinspection PyPep8Naming
-@struct(fields=[("ob_type", ptr[Self])])
+@struct
 class PyObject(Structure, Generic[_T, _KT, _VT]):
     """Defines a base PyObject Structure."""
 
     ob_refcnt: int
-    ob_type: ptr[PyObject[Type[_T], None, None]]
-    # Need to use generics from typing to work for py-3.8
+    ob_type: Annotated[ptr[PyTypeObject[Type[_T]]], c_void_p]
     _fields_: List[Union[Tuple[str, type], Tuple[str, type, int]]]
     _from_type_name_: str
 

--- a/src/einspect/types.py
+++ b/src/einspect/types.py
@@ -5,7 +5,9 @@ import typing
 from ctypes import _Pointer
 from typing import TYPE_CHECKING, List, TypeVar, get_origin, overload
 
-__all__ = ("ptr", "Array")
+from typing_extensions import Self
+
+__all__ = ("ptr", "Array", "_SelfPtr")
 
 _T = TypeVar("_T")
 
@@ -15,6 +17,9 @@ Dynamic typing alias for ctypes.pointer.
 
 Resolves to the `_Ptr` class at runtime to allow for generic subscripting.
 """
+
+_SelfPtr = object()
+"""Singleton object returned on ptr[Self]."""
 
 
 class _Ptr(_Pointer):
@@ -26,6 +31,10 @@ class _Ptr(_Pointer):
         return ctypes.pointer(*args, **kwargs)
 
     def __class_getitem__(cls, item):
+        # For ptr[Self], return a special object
+        if item is Self:
+            return _SelfPtr
+
         # Get base of generic alias
         # noinspection PyUnresolvedReferences, PyProtectedMember
         if isinstance(item, typing._GenericAlias):

--- a/src/einspect/views/_display.py
+++ b/src/einspect/views/_display.py
@@ -51,7 +51,7 @@ def format_value(
     # For PyObject, get the object
     if isinstance(obj, PyObject):
         obj.IncRef()
-        return format_value(obj.into_object().value)
+        return format_value(obj.into_object())
     # Other cases
     try:
         return DISP_TRANSFORMS[type(obj)](obj)

--- a/src/einspect/views/view_dict.py
+++ b/src/einspect/views/view_dict.py
@@ -5,7 +5,8 @@ from typing import TypeVar
 
 from einspect.api import Py_ssize_t
 from einspect.compat import abc
-from einspect.structs.py_dict import PyDictObject
+from einspect.structs.py_dict import DictKeysObject, PyDictObject
+from einspect.types import ptr
 from einspect.views.unsafe import unsafe
 from einspect.views.view_base import REF_DEFAULT, View
 
@@ -28,6 +29,7 @@ class DictView(View[dict, _KT, _VT], abc.MutableMapping[_KT, _VT]):
         ...
 
     def __getitem__(self, key: _KT) -> _VT:
+        """Get an item from the dictionary. Equivalent to dict[key]."""
         return self._pyobject.GetItem(key)
 
     def __setitem__(self, key: _KT, value: _VT) -> None:
@@ -40,7 +42,7 @@ class DictView(View[dict, _KT, _VT], abc.MutableMapping[_KT, _VT]):
 
     @property
     def used(self) -> int:
-        return self._pyobject.ma_used  # type: ignore
+        return self._pyobject.ma_used
 
     @used.setter
     @unsafe
@@ -49,7 +51,7 @@ class DictView(View[dict, _KT, _VT], abc.MutableMapping[_KT, _VT]):
 
     @property
     def version_tag(self) -> int:
-        return self._pyobject.ma_version_tag  # type: ignore
+        return self._pyobject.ma_version_tag
 
     @version_tag.setter
     @unsafe
@@ -57,8 +59,8 @@ class DictView(View[dict, _KT, _VT], abc.MutableMapping[_KT, _VT]):
         self._pyobject.ma_version_tag = value
 
     @property
-    def ma_keys(self) -> Array[Py_ssize_t]:
-        return self._pyobject.ma_keys  # type: ignore
+    def ma_keys(self) -> ptr[DictKeysObject]:
+        return self._pyobject.ma_keys
 
     @ma_keys.setter
     @unsafe

--- a/src/einspect/views/view_list.py
+++ b/src/einspect/views/view_list.py
@@ -32,7 +32,7 @@ class ListView(VarView[list, None, _VT], abc.Sequence[_VT]):
         if isinstance(index, int):
             try:
                 ptr = self._pyobject.GetItem(index)
-                return ptr.contents.into_object().value
+                return ptr.contents.into_object()
             except (IndexError, ValueError) as err:
                 raise IndexError(f"Index {index} out of range") from err
         elif isinstance(index, slice):
@@ -41,7 +41,7 @@ class ListView(VarView[list, None, _VT], abc.Sequence[_VT]):
                 start = index.start if index.start is not None else 0
                 stop = index.stop if index.stop is not None else self.size
                 ptr = self._pyobject.GetSlice(start, stop)
-                ls = ptr.contents.into_object().value
+                ls = ptr.contents.into_object()
                 # Get step if provided
                 if index.step is not None:
                     ls = ls[:: index.step]

--- a/src/einspect/views/view_mapping_proxy.py
+++ b/src/einspect/views/view_mapping_proxy.py
@@ -42,7 +42,7 @@ class MappingProxyView(View[MappingProxyType, _KT, _VT], abc.MutableMapping[_KT,
     @property
     def mapping(self) -> dict[_KT, _VT]:
         """Return `MappingProxyObject.mapping`, casted to `dict`."""
-        return self._pyobject.mapping.contents.into_object().value
+        return self._pyobject.mapping.contents.into_object()
 
     @mapping.setter
     @unsafe

--- a/src/einspect/views/view_tuple.py
+++ b/src/einspect/views/view_tuple.py
@@ -34,15 +34,14 @@ class TupleView(VarView[tuple, None, _VT], abc.Sequence):
             try:
                 ptr = self._pyobject.GetItem(index)
                 py_struct = ptr.contents
-                py_obj = py_struct.into_object()
-                return py_obj.value
+                return py_struct.into_object()
             except IndexError as err:
                 raise IndexError(f"Index {index} out of range") from err
         elif isinstance(index, slice):
             start = index.start if index.start is not None else 0
             stop = index.stop if index.stop is not None else self.size
             ptr = self._pyobject.GetSlice(start, stop)
-            return ptr.contents.into_object().value
+            return ptr.contents.into_object()
         else:
             raise TypeError(f"Invalid index type: {type(index)}")
 

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -16,7 +16,7 @@ class TestPyObject:
         ls = []
         py_object = st.PyObject.from_object(ls)
         assert py_object.ob_refcnt == 1
-        assert py_object.ob_type.contents.into_object().value == list
+        assert py_object.ob_type.contents.into_object() == list
 
     @pytest.mark.parametrize(
         ["obj", "ob_type"],
@@ -31,7 +31,7 @@ class TestPyObject:
     def test_obj(self, obj, ob_type):
         py_object = st.PyObject.from_object(obj)
         assert py_object.ob_refcnt >= 1
-        assert py_object.ob_type.contents.into_object().value == ob_type
+        assert py_object.ob_type.contents.into_object() == ob_type
 
     def test_api_setattr(self):
         obj = UserClass()
@@ -57,8 +57,8 @@ class TestPyListObject:
     def test_item(self):
         ls = [1, 2]
         pylist = st.PyListObject.from_object(ls)
-        assert pylist.ob_item[0].contents.into_object().value == 1
-        assert pylist.ob_item[1].contents.into_object().value == 2
+        assert pylist.ob_item[0].contents.into_object() == 1
+        assert pylist.ob_item[1].contents.into_object() == 2
 
         pylist.ob_item[0] = st.PyObject.from_object(5).as_ref()
         assert ls == [5, 2]

--- a/tests/views/test_view_base.py
+++ b/tests/views/test_view_base.py
@@ -59,8 +59,7 @@ class TestView:
         """Access base with reference."""
         obj = self.get_obj()
         v = self.view_type(obj, ref=True)
-        assert isinstance(v.base, ctypes.py_object)
-        assert v.base.value is obj
+        assert v.base is obj
 
     def test_base_weakref(self):
         """Access base after weakref is deleted."""
@@ -87,7 +86,7 @@ class TestView:
             # Check weakref exists
             assert v._base_weakref is not None
             assert v._base_weakref() is obj
-            assert v.base.value is obj
+            assert v.base is obj
 
     def test_base_unsafe(self):
         """Access base with unsafe."""
@@ -96,13 +95,13 @@ class TestView:
         self.check_ref(v.ref_count, 1)
 
         with v.unsafe():
-            assert v.base.value is obj
+            assert v.base is obj
 
     def test_drop(self):
         """Test accessing after drop."""
         obj = self.get_obj()
         v = self.view_type(obj, ref=True)
-        assert v.base.value is obj
+        assert v.base is obj
         v.drop()
         with pytest.raises(errors.DroppedReferenceError):
-            _ = v.base.value
+            _ = v.base

--- a/tests/views/test_view_dict.py
+++ b/tests/views/test_view_dict.py
@@ -3,27 +3,19 @@ import pytest
 from einspect.structs import PyDictObject
 from einspect.views.factory import view
 from einspect.views.view_dict import DictView
+from tests.views.test_view_base import TestView
 
 
-@pytest.fixture(scope="function")
-def obj():
-    return {"test": 1, 2: 2.0}
+class TestDictView(TestView):
+    view_type = DictView
+    obj_type = dict
 
+    def get_obj(self):
+        return {"a": 1, "b": 2}
 
-class TestDictView:
-    @pytest.mark.parametrize(
-        ["factory"],
-        [
-            (view,),
-            (DictView,),
-        ],
-    )
-    def test_factory(self, obj, factory):
-        """Test different ways of creating a ListView."""
-        v = factory(obj)
-        assert isinstance(v, DictView)
-        assert isinstance(v._pyobject, PyDictObject)
-        assert v.type == dict
+    def test_dict(self):
+        obj = self.get_obj()
+        v = self.view_type(obj)
+        assert v.type is dict
         assert v.used == len(obj)
-        assert v.base.value is obj
-        assert ~v is obj
+        # assert v.ma_keys.contents == 0

--- a/tests/views/test_view_mapping_proxy.py
+++ b/tests/views/test_view_mapping_proxy.py
@@ -30,5 +30,5 @@ class TestTupleView:
         assert isinstance(v._pyobject, MappingProxyObject)
         assert v.type == MappingProxyType
         assert v.mapping == {"a": 1, "b": 2}
-        assert v.base.value is obj
+        assert v.base is obj
         assert ~v is obj

--- a/tests/views/test_view_tuple.py
+++ b/tests/views/test_view_tuple.py
@@ -19,7 +19,7 @@ class TestTupleView(TestView):
     def test_item(self):
         obj = self.get_obj()
         v = self.view_type(obj)
-        assert v.item[0].contents.into_object().value is obj[0]
+        assert v.item[0].contents.into_object() is obj[0]
 
     def test_get_item(self):
         obj = self.get_obj()


### PR DESCRIPTION
- Remove need for py_object wrapper step in `PyObject.into_object` resolution
- Define a more accurate subtype `ptr[PyTypeObject]` instead of `ptr[PyObject]` for `PyObject.ob_type`