### PR TITLE
Fix StrView base access, add PyObject.from_gc, display info for DictView

### DIFF
--- a/docs/source/api/structs/index.md
+++ b/docs/source/api/structs/index.md
@@ -1,0 +1,18 @@
+# structs
+
+```{toctree}
+:maxdepth: 2
+
+py_object
+py_bool
+py_dict
+py_float
+py_gc
+py_long
+py_list
+mapping_proxy
+py_set
+py_unicode
+py_tuple
+py_type
+```

--- a/docs/source/api/structs/mapping_proxy.rst
+++ b/docs/source/api/structs/mapping_proxy.rst
@@ -1,0 +1,6 @@
+MappingProxyObject
+==================
+
+.. autoclass:: einspect.structs.mapping_proxy.MappingProxyObject
+   :members:
+   :inherited-members:

--- a/docs/source/api/structs/py_bool.rst
+++ b/docs/source/api/structs/py_bool.rst
@@ -1,0 +1,6 @@
+PyBoolObject
+============
+
+.. autoclass:: einspect.structs.py_bool.PyBoolObject
+   :members:
+   :inherited-members:

--- a/docs/source/api/structs/py_dict.rst
+++ b/docs/source/api/structs/py_dict.rst
@@ -1,0 +1,6 @@
+PyDictObject
+============
+
+.. autoclass:: einspect.structs.py_dict.PyDictObject
+   :members:
+   :inherited-members:

--- a/docs/source/api/structs/py_float.rst
+++ b/docs/source/api/structs/py_float.rst
@@ -1,0 +1,6 @@
+PyFloatObject
+=============
+
+.. autoclass:: einspect.structs.py_float.PyFloatObject
+   :members:
+   :inherited-members:

--- a/docs/source/api/structs/py_gc.rst
+++ b/docs/source/api/structs/py_gc.rst
@@ -1,0 +1,9 @@
+PyGC_Head
+=========
+
+.. autoclass:: einspect.structs.py_gc.PyGC_Head
+   :members:
+   :inherited-members:
+
+.. autoclass:: einspect.structs.py_gc.PyGC
+   :members:

--- a/docs/source/api/structs/py_list.rst
+++ b/docs/source/api/structs/py_list.rst
@@ -1,0 +1,6 @@
+PyListObject
+============
+
+.. autoclass:: einspect.structs.py_list.PyListObject
+   :members:
+   :inherited-members:

--- a/docs/source/api/structs/py_long.rst
+++ b/docs/source/api/structs/py_long.rst
@@ -1,0 +1,6 @@
+PyLongObject
+============
+
+.. autoclass:: einspect.structs.py_long.PyLongObject
+   :members:
+   :inherited-members:

--- a/docs/source/api/structs/py_object.rst
+++ b/docs/source/api/structs/py_object.rst
@@ -1,0 +1,14 @@
+PyObject
+========
+
+.. autoclass:: einspect.structs.py_object.PyObject
+   :members:
+   :inherited-members:
+
+
+PyVarObject
+===========
+
+.. autoclass:: einspect.structs.py_object.PyVarObject
+   :members:
+   :inherited-members:

--- a/docs/source/api/structs/py_set.rst
+++ b/docs/source/api/structs/py_set.rst
@@ -1,0 +1,6 @@
+PySetObject
+===========
+
+.. autoclass:: einspect.structs.py_set.PySetObject
+   :members:
+   :inherited-members:

--- a/docs/source/api/structs/py_tuple.rst
+++ b/docs/source/api/structs/py_tuple.rst
@@ -1,0 +1,6 @@
+PyTupleObject
+=============
+
+.. autoclass:: einspect.structs.py_tuple.PyTupleObject
+   :members:
+   :inherited-members:

--- a/docs/source/api/structs/py_type.rst
+++ b/docs/source/api/structs/py_type.rst
@@ -1,0 +1,6 @@
+PyTypeObject
+============
+
+.. autoclass:: einspect.structs.py_type.PyTypeObject
+   :members:
+   :inherited-members:

--- a/docs/source/api/structs/py_unicode.rst
+++ b/docs/source/api/structs/py_unicode.rst
@@ -1,0 +1,6 @@
+PyUnicodeObject
+===============
+
+.. autoclass:: einspect.structs.py_unicode.PyUnicodeObject
+   :members:
+   :inherited-members:

--- a/docs/source/api/views/index.md
+++ b/docs/source/api/views/index.md
@@ -10,6 +10,7 @@ view_float
 view_int
 view_list
 view_mapping_proxy
+view_set
 view_str
 view_tuple
 view_type

--- a/docs/source/api/views/view_set.rst
+++ b/docs/source/api/views/view_set.rst
@@ -1,0 +1,6 @@
+SetView
+=======
+
+.. autoclass:: einspect.views.view_set.SetView
+   :members:
+   :inherited-members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
 project = "einspect"
 copyright = "2023, Ionite"
 author = "Ionite"
-release = "v0.4.4"
+release = "v0.4.5"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -14,6 +14,7 @@ views.md
 :caption: API
 :hidden:
 api/views/index.md
+api/structs/index.md
 ```
 
 ```{toctree}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "einspect"
-version = "0.4.4"
+version = "0.4.5"
 description = "Extended Inspect - view and modify memory structs of runtime objects."
 authors = ["ionite34 <dev@ionite.io>"]
 license = "MIT"

--- a/src/einspect/__init__.py
+++ b/src/einspect/__init__.py
@@ -9,6 +9,6 @@ from einspect.views.view_type import impl
 
 __all__ = ("view", "unsafe", "impl", "orig")
 
-__version__ = "0.4.4"
+__version__ = "0.4.5"
 
 unsafe: ContextManager[None] = global_unsafe

--- a/src/einspect/api.py
+++ b/src/einspect/api.py
@@ -1,4 +1,4 @@
-"""CPython API Methods."""
+"""CPython API Methods and intrinsic constants."""
 import ctypes
 from ctypes import POINTER, py_object, pythonapi
 from typing import Callable, Union

--- a/src/einspect/api.py
+++ b/src/einspect/api.py
@@ -1,6 +1,6 @@
 """CPython API Methods and intrinsic constants."""
 import ctypes
-from ctypes import POINTER, py_object, pythonapi
+from ctypes import POINTER, c_void_p, py_object, pythonapi, sizeof
 from typing import Callable, Union
 
 import _ctypes
@@ -8,7 +8,16 @@ import _ctypes
 from einspect.compat import Version, python_req
 from einspect.protocols.delayed_bind import bind_api
 
-__all__ = ("Py", "Py_ssize_t", "Py_hash_t", "uintptr_t", "PyObj_FromPtr")
+__all__ = (
+    "Py",
+    "Py_ssize_t",
+    "Py_hash_t",
+    "uintptr_t",
+    "PyObj_FromPtr",
+    "ALIGNMENT",
+    "ALIGNMENT_SHIFT",
+    "align_size",
+)
 
 Py_ssize_t = ctypes.c_ssize_t
 """Constant for type Py_ssize_t."""
@@ -22,6 +31,15 @@ uintptr_t = ctypes.c_uint64
 ObjectOrRef = Union[py_object, object]
 IntSize = Union[int, Py_ssize_t]
 PyObjectPtr = POINTER(py_object)
+
+# Alignments (must be powers of 2)
+# https://github.com/python/cpython/blob/3.11/Objects/obmalloc.c#L878-L884
+if sizeof(c_void_p) > 4:
+    ALIGNMENT = 16
+    ALIGNMENT_SHIFT = 4
+else:
+    ALIGNMENT = 8
+    ALIGNMENT_SHIFT = 3
 
 
 # noinspection PyPep8Naming
@@ -113,3 +131,8 @@ class Py:
 
 PyObj_FromPtr: Callable[[IntSize], object] = _ctypes.PyObj_FromPtr
 """(Py_ssize_t ptr) -> Py_ssize_t"""
+
+
+def align_size(size: int, alignment: int = ALIGNMENT) -> int:
+    """Align size to alignment."""
+    return (size + alignment - 1) & ~(alignment - 1)

--- a/src/einspect/protocols/type_parse.py
+++ b/src/einspect/protocols/type_parse.py
@@ -25,7 +25,7 @@ class FuncPtr(Protocol):
     argtypes: Sequence[type]
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        ...
+        ...  # pragma: no cover
 
 
 aliases = {

--- a/src/einspect/structs/py_dict.py
+++ b/src/einspect/structs/py_dict.py
@@ -3,22 +3,27 @@ from __future__ import annotations
 from ctypes import (
     POINTER,
     Structure,
+    _SimpleCData,
+    addressof,
     c_char,
+    c_int8,
+    c_int16,
+    c_int32,
+    c_int64,
     c_uint8,
     c_uint32,
     c_uint64,
-    c_void_p,
     pythonapi,
 )
 from typing import Dict, TypeVar
 
 from typing_extensions import Annotated
 
-from einspect.api import Py_ssize_t
 from einspect.protocols.delayed_bind import bind_api
 from einspect.structs.deco import struct
-from einspect.structs.py_object import PyObject
-from einspect.types import ptr
+from einspect.structs.py_object import Fields, PyObject
+from einspect.structs.traits import Display
+from einspect.types import Array, ptr
 
 __all__ = ("PyDictObject",)
 
@@ -28,24 +33,73 @@ _VT = TypeVar("_VT")
 
 
 @struct
-class DictKeysObject(Structure):
+class PyDictKeysObject(Structure, Display):
     """
     Defines a DictKeysObject Structure.
 
     https://github.com/python/cpython/blob/3.11/Include/internal/pycore_dict.h#L87-L125
     """
 
-    dk_refcnt: Py_ssize_t
-    dk_log2_size: c_uint8
-    dk_log2_index_bytes: c_uint8
-    dk_kind: c_uint8
-    dk_version: c_uint32
-    dk_usable: Py_ssize_t
-    dk_nentries: Py_ssize_t
-    dk_indices: POINTER(c_char)
+    dk_refcnt: int
+    dk_log2_size: Annotated[int, c_uint8]
+    dk_log2_index_bytes: Annotated[int, c_uint8]
+    dk_kind: Annotated[int, c_uint8]
+    dk_version: Annotated[int, c_uint32]
+    dk_usable: int
+    dk_nentries: int
+    # Actual hash table of dk_size entries. It holds indices in dk_entries,
+    # or DKIX_EMPTY(-1) or DKIX_DUMMY(-2).
+    # Indices must be: 0 <= indice < USABLE_FRACTION(dk_size).
+    #
+    # The size in bytes of an indice depends on dk_size:
+    # - 1 byte if dk_size <= 0xff (char*)
+    # - 2 bytes if dk_size <= 0xffff (int16_t*)
+    # - 4 bytes if dk_size <= 0xffffffff (int32_t*)
+    # - 8 bytes otherwise (int64_t*)
+    #
+    # Dynamically sized, SIZEOF_VOID_P is minimum.
+    _dk_indices: c_int8 * 0
+
+    @property
+    def dk_indices(self) -> Array[int]:
+        print("dk_indices", self._dk_indices)
+        items_addr = addressof(self._dk_indices)
+        item_type = self._dk_indices_type()[0]
+        arr = item_type * self._dk_size
+        return arr.from_address(items_addr)
+
+    @property
+    def _dk_size(self) -> int:
+        return 1 << self.dk_log2_size
+
+    def _dk_indices_type(self) -> tuple[_SimpleCData, str]:
+        if self._dk_size <= 0xFF:
+            return c_char, "c_char"
+        elif self._dk_size <= 0xFFFF:
+            return c_int16, "c_int16"
+        elif self._dk_size <= 0xFFFFFFFF:
+            return c_int32, "c_int32"
+        return c_int64, "c_int64"
+
+    def _format_fields_(self) -> Fields:
+        indice_type, indice_name = self._dk_indices_type()
+        return {
+            "dk_refcnt": "Py_ssize_t",
+            "dk_log2_size": "c_uint8",
+            "dk_log2_index_bytes": "c_uint8",
+            "dk_kind": "c_uint8",
+            "dk_version": "c_uint32",
+            "dk_usable": "Py_ssize_t",
+            "dk_nentries": "Py_ssize_t",
+            "dk_indices": f"Array[{indice_name}]",
+        }
 
 
-# noinspection PyPep8Naming
+@struct
+class PyDictValues(Structure, Display):
+    values: ptr[PyObject]
+
+
 @struct
 class PyDictObject(PyObject[dict, _KT, _VT]):
     """
@@ -58,11 +112,20 @@ class PyDictObject(PyObject[dict, _KT, _VT]):
     ma_used: int
     # Dictionary version: globally unique, changes on modification
     ma_version_tag: Annotated[int, c_uint64]
-    ma_keys: ptr[DictKeysObject]
+    ma_keys: ptr[PyDictKeysObject]
     # If ma_values is NULL, the table is "combined": keys and values
     # are stored in ma_keys. Otherwise, keys are stored in ma_keys
     # and values are stored in ma_values
-    ma_values: POINTER(c_void_p)
+    ma_values: ptr[PyDictValues]
+
+    def _format_fields_(self) -> Fields:
+        return {
+            **super()._format_fields_(),
+            "ma_used": "Py_ssize_t",
+            "ma_version_tag": "c_uint64",
+            "ma_keys": "*PyDictKeysObject",
+            "ma_values": "*PyDictValues",
+        }
 
     @bind_api(pythonapi["PyDict_GetItem"])
     def GetItem(self, key: _KT) -> POINTER(PyObject):

--- a/src/einspect/structs/py_gc.py
+++ b/src/einspect/structs/py_gc.py
@@ -7,7 +7,8 @@ from typing_extensions import Annotated
 
 from einspect.api import uintptr_t
 from einspect.structs.deco import struct
-from einspect.types import AsRef, ptr
+from einspect.structs.traits import AsRef
+from einspect.types import ptr
 
 
 class PyGC(IntEnum):

--- a/src/einspect/structs/py_long.py
+++ b/src/einspect/structs/py_long.py
@@ -26,7 +26,7 @@ class PyLongObject(PyVarObject[int, None, None]):
         # Need to add size(uint32) * ob_size to our base size
         base = super().mem_size
         # use size 1 if ob_size is 0 due to allocation
-        size = min(1, abs(self.ob_size))
+        size = max(1, abs(self.ob_size))
         return base + ctypes.sizeof(c_uint32) * size
 
     @property

--- a/src/einspect/structs/py_object.py
+++ b/src/einspect/structs/py_object.py
@@ -11,7 +11,8 @@ from einspect.compat import Version, python_req
 from einspect.protocols.delayed_bind import bind_api
 from einspect.structs.deco import struct
 from einspect.structs.py_gc import PyGC_Head
-from einspect.types import AsRef, ptr
+from einspect.structs.traits import AsRef
+from einspect.types import ptr
 
 if TYPE_CHECKING:
     from einspect.structs import PyTypeObject

--- a/src/einspect/structs/py_object.py
+++ b/src/einspect/structs/py_object.py
@@ -90,6 +90,12 @@ class PyObject(Structure, AsRef, Generic[_T, _KT, _VT]):
         inst._from_type_name_ = type_repr
         return inst
 
+    @classmethod
+    def from_gc(cls, gc: PyGC_Head) -> Self:
+        """Create a PyObject from a PyGC_Head struct."""
+        addr = ctypes.addressof(gc) + ctypes.sizeof(PyGC_Head)
+        return cls.from_address(addr)
+
     def into_object(self) -> _T:
         """Cast the PyObject into a Python object."""
         py_obj = ctypes.cast(self.as_ref(), ctypes.py_object)

--- a/src/einspect/structs/traits.py
+++ b/src/einspect/structs/traits.py
@@ -1,0 +1,25 @@
+"""Traits and mixins for structs."""
+from ctypes import Structure, addressof, pointer
+
+from typing_extensions import Self
+
+from einspect.types import ptr
+
+
+class AsRef:
+    """Mixin for an as_ref method."""
+
+    def as_ref(self) -> ptr[Self]:
+        """Return a pointer to the Structure."""
+        return pointer(self)  # type: ignore
+
+
+class Display:
+    """Mixin for displaying Structures."""
+
+    def __repr__(self: Structure) -> str:
+        """
+        Return a string representation of the Structure.
+        The address shown is the address of the Structure, not the object.
+        """
+        return f"<{self.__class__.__name__} at {addressof(self):#04x}>"

--- a/src/einspect/types.py
+++ b/src/einspect/types.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, List, TypeVar, get_origin, overload
 
 from typing_extensions import Self
 
-__all__ = ("ptr", "Array", "AsRef", "_SelfPtr")
+__all__ = ("ptr", "Array", "_SelfPtr")
 
 _T = TypeVar("_T")
 
@@ -81,9 +81,3 @@ if not TYPE_CHECKING:
             "Array": ctypes.Array,
         }
     )
-
-
-class AsRef:
-    def as_ref(self) -> ptr[Self]:
-        """Return a pointer to the Structure."""
-        return ctypes.pointer(self)  # type: ignore

--- a/src/einspect/views/_display.py
+++ b/src/einspect/views/_display.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import ctypes
-from ctypes import Array
+from ctypes import Array, Structure, cast
 from string import Template
 from typing import TYPE_CHECKING, Any
 
@@ -21,73 +21,100 @@ DISP_TRANSFORMS = {
 }
 
 
-def format_value(
-    obj: Any, cast_to: type | None = None, arr_bound: int | None = None
-) -> str:
-    """
-    Format a value.
-
-    Args:
-        obj: The value to format
-        cast_to: The type to cast the value to
-        arr_bound: The max number of pointers to dereference for Array[PyObject] types
-    """
-    # Cast if needed
-    if cast_to is not None:
-        obj = ctypes.cast(obj, cast_to)  # type: ignore
-        return format_value(obj)
-    # Array: format as list
-    if isinstance(obj, Array):
-        # Only get elements up to arr_bound
-        res = list(map(format_value, obj[:arr_bound]))
-        diff = len(obj) - len(res)
-        return f"[{', '.join(res)}{', ...' if diff > 0 else ''}]"
-    # For pointers, get the value
-    # noinspection PyUnresolvedReferences, PyProtectedMember
-    if isinstance(obj, ctypes._Pointer):
-        val = format_value(obj.contents) if obj else "NULL"
-        wrap = f"[{val}]" if not (val.startswith("[") and val.endswith("]")) else val
-        return f"&{wrap}"
-    # For PyObject, get the object
-    if isinstance(obj, PyObject):
-        obj.IncRef()
-        return format_value(obj.into_object())
-    # Other cases
-    try:
-        return DISP_TRANSFORMS[type(obj)](obj)
-    except KeyError:
-        return repr(obj)
-
-
-def format_attr(
-    struct: PyObject, attr: str, hint: str | tuple[str, type], types: bool
-) -> str:
-    value = getattr(struct, attr)
-    type_cast = None
-    if isinstance(hint, tuple):
-        hint, type_cast = hint
-    type_str = f": {hint}" if types else ""
-    res = f"{attr}{type_str} = {format_value(value, cast_to=type_cast)}"
-    return res
-
-
 def indent(s: str) -> str:
     """Indent a string."""
-    return INDENTS + s
+    # For single line strings, just add indents
+    if "\n" not in s:
+        return INDENTS + s
+    # For multi-line, add indents to each line
+    return "\n".join(INDENTS + line for line in s.splitlines())
 
 
-# noinspection PyProtectedMember
-def format_display(v: View, types: bool = True) -> str:
-    lines = []
-    # Get struct
-    struct = v._pyobject
-    struct_name = struct.__class__.__name__
-    address = f"0x{struct.address:x}"
-    # Make line 1
-    lines.append(BASE.substitute(struct_name=struct_name, address=address))
+class Formatter:
+    def __init__(self, types: bool = True, arr_max: int | None = None):
+        """
+        Initialize a Formatter.
 
-    # Get attributes
-    for attr, type_hint in struct._format_fields_().items():
-        lines.append(indent(format_attr(struct, attr, type_hint, types)))
+        Args:
+            types: Whether to include type hints.
+            arr_max: The max number of elements to show for Array types.
+        """
+        self.types = types
+        self.arr_max = arr_max
 
-    return "\n".join(lines)
+    def format_value(self, obj: Any) -> str:
+        """Format a value."""
+        # Array: format as list
+        if isinstance(obj, Array):
+            # If there is a max, limit the number of elements
+            diff = 0
+            if self.arr_max is not None and len(obj) > self.arr_max:
+                diff = len(obj) - self.arr_max
+                obj = obj[: self.arr_max]
+            res = list(map(self.format_value, obj))
+            print(f"diff: {diff}")
+            return f"[{', '.join(res)}{', ...' if diff > 0 else ''}]"
+        # For pointers, get the value
+        # noinspection PyUnresolvedReferences, PyProtectedMember
+        if isinstance(obj, ctypes._Pointer):
+            val = self.format_value(obj.contents) if obj else "NULL"
+            wrap = (
+                f"[{val}]" if not (val.startswith("[") and val.endswith("]")) else val
+            )
+            return f"&{wrap}"
+        # For PyObject, get the object
+        if isinstance(obj, PyObject):
+            obj.IncRef()
+            return self.format_value(obj.into_object())
+        # For ctypes Structures, do multi-line formatting
+        if isinstance(obj, Structure):
+            return self.format_structure(obj)
+        # Other cases
+        try:
+            return DISP_TRANSFORMS[type(obj)](obj)
+        except KeyError:
+            return repr(obj)
+
+    def format_attr(
+        self,
+        struct: PyObject,
+        attr: str,
+        hint: str | tuple[str, type],
+    ) -> str:
+        value = getattr(struct, attr)
+        type_cast = None
+        if isinstance(hint, tuple):
+            hint, type_cast = hint
+        type_str = f": {hint}" if self.types else ""
+
+        # If cast_to provided
+        if type_cast is not None:
+            value = cast(value, type_cast)
+
+        res = f"{attr}{type_str} = {self.format_value(value)}"
+        return res
+
+    # noinspection PyProtectedMember
+    def format_structure(self, struct: Structure) -> str:
+        lines = []
+        # Get attributes
+        for attr, type_hint in struct._format_fields_().items():
+            res = indent(self.format_attr(struct, attr, type_hint))
+            lines.append(res)
+        return "\n" + "\n".join(lines) + "\n"
+
+    # noinspection PyProtectedMember
+    def format_view(self, v: View) -> str:
+        """Format a display string for a View."""
+        lines = []
+        # Get struct
+        struct = v._pyobject
+        struct_name = struct.__class__.__name__
+        address = f"0x{struct.address:x}"
+        # Make line 1
+        lines.append(BASE.substitute(struct_name=struct_name, address=address))
+        # Get attributes
+        for attr, type_hint in struct._format_fields_().items():
+            lines.append(indent(self.format_attr(struct, attr, type_hint)))
+
+        return "\n".join(lines)

--- a/src/einspect/views/view_base.py
+++ b/src/einspect/views/view_base.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from ctypes import py_object
 from typing import Final, Generic, Type, TypeVar, get_type_hints
 
-from einspect.api import Py, PyObj_FromPtr
+from einspect.api import Py, PyObj_FromPtr, align_size
 from einspect.errors import (
     DroppedReference,
     MovedError,
@@ -180,6 +180,11 @@ class View(BaseView[_T, _KT, _VT]):
     def mem_size(self) -> int:
         """Memory size of the object in bytes."""
         return self._pyobject.mem_size
+
+    @property
+    def mem_allocated(self) -> int:
+        """Memory allocated for the object in bytes."""
+        return align_size(self.mem_size)
 
     def is_gc(self) -> bool:
         """

--- a/src/einspect/views/view_base.py
+++ b/src/einspect/views/view_base.py
@@ -7,7 +7,7 @@ import weakref
 from abc import ABC
 from contextlib import ExitStack
 from copy import deepcopy
-from ctypes import py_object, sizeof
+from ctypes import py_object
 from typing import Final, Generic, Type, TypeVar, get_type_hints
 
 from einspect.api import Py, PyObj_FromPtr
@@ -179,7 +179,7 @@ class View(BaseView[_T, _KT, _VT]):
     @property
     def mem_size(self) -> int:
         """Memory size of the object in bytes."""
-        return sizeof(self._pyobject)
+        return self._pyobject.mem_size
 
     def is_gc(self) -> bool:
         """

--- a/src/einspect/views/view_base.py
+++ b/src/einspect/views/view_base.py
@@ -18,7 +18,7 @@ from einspect.errors import (
     UnsafeError,
 )
 from einspect.structs import PyObject, PyVarObject
-from einspect.views._display import format_display
+from einspect.views._display import Formatter
 from einspect.views.unsafe import UnsafeContext, unsafe
 
 __all__ = ("View", "VarView", "AnyView", "REF_DEFAULT")
@@ -80,9 +80,18 @@ class View(BaseView[_T, _KT, _VT]):
         py_obj_cls = self._pyobject.__class__.__name__
         return f"{self.__class__.__name__}(<{py_obj_cls} at 0x{addr:x}>)"
 
-    def info(self, types: bool = True) -> str:
-        """Returns info about the view."""
-        return format_display(self, types=types)
+    def info(self, types: bool = True, arr_max: int | None = 64) -> str:
+        """
+        Return a formatted info string of the view struct.
+
+        Args:
+            types: If True, include types as annotations.
+            arr_max: Maximum length of Array elements to display.
+
+        Returns:
+            A formatted info string of the view struct.
+        """
+        return Formatter(types, arr_max).format_view(self)
 
     @property
     def ref_count(self) -> int:

--- a/src/einspect/views/view_dict.py
+++ b/src/einspect/views/view_dict.py
@@ -5,7 +5,7 @@ from typing import TypeVar
 
 from einspect.api import Py_ssize_t
 from einspect.compat import abc
-from einspect.structs.py_dict import DictKeysObject, PyDictObject
+from einspect.structs.py_dict import PyDictKeysObject, PyDictObject
 from einspect.types import ptr
 from einspect.views.unsafe import unsafe
 from einspect.views.view_base import REF_DEFAULT, View
@@ -61,7 +61,7 @@ class DictView(View[dict, _KT, _VT], abc.MutableMapping[_KT, _VT]):
         self._pyobject.ma_version_tag = value
 
     @property
-    def ma_keys(self) -> ptr[DictKeysObject]:
+    def ma_keys(self) -> ptr[PyDictKeysObject]:
         return self._pyobject.ma_keys
 
     @ma_keys.setter

--- a/src/einspect/views/view_int.py
+++ b/src/einspect/views/view_int.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ctypes import Array, c_uint32, sizeof
+from ctypes import Array, c_uint32
 from typing import Iterable, TypeVar
 
 from einspect.structs import PyLongObject
@@ -13,12 +13,6 @@ _T = TypeVar("_T")
 
 class IntView(VarView[int, None, None]):
     _pyobject: PyLongObject
-
-    @property
-    def mem_size(self) -> int:
-        size = min(1, self.size)
-        arr_size = size * sizeof(c_uint32)
-        return sizeof(PyLongObject) + arr_size
 
     @property
     def digits(self) -> Array[c_uint32]:

--- a/src/einspect/views/view_list.py
+++ b/src/einspect/views/view_list.py
@@ -30,50 +30,34 @@ class ListView(VarView[list, None, _VT], abc.Sequence[_VT]):
 
     def __getitem__(self, index: int | slice) -> _VT | list[_VT]:
         if isinstance(index, int):
-            try:
-                ptr = self._pyobject.GetItem(index)
-                return ptr.contents.into_object()
-            except (IndexError, ValueError) as err:
-                raise IndexError(f"Index {index} out of range") from err
+            ptr = self._pyobject.GetItem(index)
+            return ptr.contents.into_object()
         elif isinstance(index, slice):
-            try:
-                # Normalize slice start and stop
-                start = index.start if index.start is not None else 0
-                stop = index.stop if index.stop is not None else self.size
-                ptr = self._pyobject.GetSlice(start, stop)
-                ls = ptr.contents.into_object()
-                # Get step if provided
-                if index.step is not None:
-                    ls = ls[:: index.step]
-                return ls
-            except (IndexError, ValueError) as err:
-                raise IndexError(f"Slice {index} out of range") from err
-
+            # Normalize slice start and stop
+            start = index.start if index.start is not None else 0
+            stop = index.stop if index.stop is not None else self.size
+            ptr = self._pyobject.GetSlice(start, stop)
+            ls = ptr.contents.into_object()
+            # Get step if provided
+            if index.step is not None:
+                ls = ls[:: index.step]
+            return ls
         raise TypeError(f"Invalid index type: {type(index)}")
 
     def __setitem__(self, index: int, value: _VT) -> None:
         if isinstance(index, int):
-            try:
-                self._pyobject.SetItem(index.__index__(), value)
-            except (IndexError, ValueError) as err:
-                raise IndexError(f"Index {index} out of range") from err
+            self._pyobject.SetItem(index.__index__(), value)
         elif isinstance(index, slice):
-            try:
-                if index.step is not None:
-                    raise ValueError("Cannot set slice with step")
-                # Normalize slice start and stop
-                start = index.start if index.start is not None else 0
-                stop = index.stop if index.stop is not None else self.size
-                self._pyobject.SetSlice(start, stop, value)
-            except (IndexError, ValueError) as err:
-                raise IndexError(f"Slice {index} out of range") from err
+            if index.step is not None:
+                raise ValueError("Cannot set slice with step")
+            # Normalize slice start and stop
+            start = index.start if index.start is not None else 0
+            stop = index.stop if index.stop is not None else self.size
+            self._pyobject.SetSlice(start, stop, value)
         else:
             raise TypeError(f"Invalid index type: {type(index)}")
 
     def __len__(self) -> int:
-        x = self.size
-        if x > 5:
-            return x
         return self.size
 
     @property

--- a/src/einspect/views/view_str.py
+++ b/src/einspect/views/view_str.py
@@ -20,7 +20,7 @@ class StrView(View[str, None, None], Sequence):
 
     @property
     def mem_size(self) -> int:
-        return object.__sizeof__(self.base.value)
+        return object.__sizeof__(self.base)
 
     @property
     def length(self) -> int:
@@ -60,7 +60,7 @@ class StrView(View[str, None, None], Sequence):
         return self._pyobject.buffer
 
     def __len__(self) -> int:
-        return str.__len__(self.base.value)  # type: ignore
+        return str.__len__(self.base)
 
     @overload
     def __getitem__(self, index: int) -> _T:
@@ -71,4 +71,4 @@ class StrView(View[str, None, None], Sequence):
         ...
 
     def __getitem__(self, index: int | slice) -> _T:
-        return str.__getitem__(self.base.value, index)  # type: ignore
+        return str.__getitem__(self.base, index)

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -111,9 +111,7 @@ class TestPyTypeObject:
 @pytest.mark.parametrize(
     ["obj", "struct", "size"],
     [
-        (False, st.PyBoolObject, (3 * 8)),
         (True, st.PyBoolObject, (3 * 8) + 4),
-        (0, st.PyLongObject, (3 * 8)),
         (50, st.PyLongObject, (3 * 8) + 4),
         ((1, 2), st.PyTupleObject, (3 * 8) + (2 * 8)),
     ],

--- a/tests/test_type_parse.py
+++ b/tests/test_type_parse.py
@@ -1,0 +1,23 @@
+from ctypes import POINTER, c_void_p
+
+import pytest
+
+from einspect.structs.deco import struct
+
+
+def test_struct():
+    @struct
+    class Foo:
+        x: POINTER(c_void_p)
+
+    assert Foo
+
+
+def test_struct_pointer_error():
+    with pytest.raises(TypeError):
+
+        @struct
+        class Foo:
+            x: POINTER(str)  # type: ignore
+
+        assert not Foo

--- a/tests/views/test_move.py
+++ b/tests/views/test_move.py
@@ -22,3 +22,13 @@ def test_move_from():
         v.move_from(view(5))
     assert x == 5
     assert id(x) != id(5)
+
+
+@pytest.mark.run_in_subprocess
+def test_move_tuple():
+    tup = literal_eval("(1, 2)")
+    v = view(tup)
+    with v.unsafe():
+        v <<= ("A", "B", "C")
+
+    assert tup == ("A", "B", "C")

--- a/tests/views/test_view_int.py
+++ b/tests/views/test_view_int.py
@@ -2,6 +2,7 @@ import ctypes
 
 import pytest
 
+from einspect.api import ALIGNMENT
 from einspect.views import BoolView
 from einspect.views.view_int import IntView
 from tests.views.test_view_base import TestView
@@ -13,6 +14,17 @@ class TestIntView(TestView):
 
     def get_obj(self):
         return 2**128 + 5
+
+    def test_memsize(self):
+        obj = self.get_obj()
+        v = self.view_type(obj)
+        expected = obj.__sizeof__()
+        assert v.mem_size == expected
+
+        if v.mem_size % ALIGNMENT == 0:
+            assert v.mem_allocated == expected
+        else:
+            assert v.mem_allocated == expected + (ALIGNMENT - expected % ALIGNMENT)
 
     def test_digits(self):
         obj = self.get_obj()
@@ -35,8 +47,8 @@ class TestBoolView(TestIntView):
 
     def test_memsize(self):
         v = self.view_type(True)
-        expect_size = True.__sizeof__()
-        assert v.mem_size == expect_size
+        expected = True.__sizeof__()
+        assert v.mem_size == expected
 
     def test_singleton_true(self):
         v = self.view_type(True)

--- a/tests/views/test_view_list.py
+++ b/tests/views/test_view_list.py
@@ -19,7 +19,7 @@ class TestListView(TestView):
         obj = [1, 2, 3]
         v = self.view_type(obj)
         assert v.size == len(obj)
-        assert v.allocated == 4
+        assert v.allocated >= len(obj)
         for i in range(3):
             assert v.item[i].contents.into_object() is obj[i]
 

--- a/tests/views/test_view_list.py
+++ b/tests/views/test_view_list.py
@@ -32,7 +32,16 @@ class TestListView(TestView):
         assert v[1] == obj[1]
         assert v[2] == obj[2]
         assert v[:2] == obj[:2]
+        assert v[::-1] == obj[::-1]
         assert v[:] == obj[:]
+
+    def test_getitem_error(self):
+        obj = self.get_obj()
+        v = self.view_type(obj)
+        with pytest.raises(IndexError):
+            _ = v[len(obj)]
+        with pytest.raises(TypeError):
+            _ = v["abc"]  # type: ignore
 
     def test_setitem(self):
         obj = [1, 2, 3]

--- a/tests/views/test_view_list.py
+++ b/tests/views/test_view_list.py
@@ -15,6 +15,14 @@ class TestListView(TestView):
     def get_obj(self):
         return [400, 500, 600]
 
+    def test_attrs(self):
+        obj = [1, 2, 3]
+        v = self.view_type(obj)
+        assert v.size == len(obj)
+        assert v.allocated == 4
+        for i in range(3):
+            assert v.item[i].contents.into_object() is obj[i]
+
     def test_sized(self):
         obj = self.get_obj()
         orig_len = len(obj)
@@ -53,3 +61,10 @@ class TestListView(TestView):
         assert obj == [10, "hi", "abc"]
         v[:] = ("A", "B")
         assert obj == ["A", "B"]
+
+    def test_setitem_error(self):
+        obj = [1, 2, 3]
+        v = self.view_type(obj)
+        # Cannot set slice with step
+        with pytest.raises(ValueError):
+            v[1:2:2] = [1, 2]

--- a/tests/views/test_view_tuple.py
+++ b/tests/views/test_view_tuple.py
@@ -30,6 +30,12 @@ class TestTupleView(TestView):
         assert v[:2] == obj[:2]
         assert v[:] == obj[:]
 
+    def test_get_item_error(self):
+        obj = self.get_obj()
+        v = self.view_type(obj)
+        with pytest.raises(IndexError):
+            _ = v[len(obj)]
+
     def test_error_set_slice(self):
         obj = self.get_obj()
         v = self.view_type(obj)


### PR DESCRIPTION
## Adds
- View.mem_allocated (property)
- Full formatting support in DictView.info()

## Fixes
- TupleView.mem_size now uses more accurate implementation from PyTupleObject