### PR TITLE
Add MutableSequence protocols for TupleView

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
 project = "einspect"
 copyright = "2023, Ionite"
 author = "Ionite"
-release = "v0.4.5"
+release = "v0.4.6"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "einspect"
-version = "0.4.5"
+version = "0.4.6a1"
 description = "Extended Inspect - view and modify memory structs of runtime objects."
 authors = ["ionite34 <dev@ionite.io>"]
 license = "MIT"

--- a/src/einspect/__init__.py
+++ b/src/einspect/__init__.py
@@ -9,6 +9,6 @@ from einspect.views.view_type import impl
 
 __all__ = ("view", "unsafe", "impl", "orig")
 
-__version__ = "0.4.5"
+__version__ = "0.4.6a1"
 
 unsafe: ContextManager[None] = global_unsafe

--- a/src/einspect/views/view_base.py
+++ b/src/einspect/views/view_base.py
@@ -8,6 +8,7 @@ from abc import ABC
 from contextlib import ExitStack
 from copy import deepcopy
 from ctypes import py_object
+from functools import cached_property
 from typing import Final, Generic, Type, TypeVar, get_type_hints
 
 from einspect.api import Py, PyObj_FromPtr, align_size
@@ -74,6 +75,7 @@ class View(BaseView[_T, _KT, _VT]):
         struct_type = get_type_hints(self.__class__)["_pyobject"]
         self._pyobject = struct_type.from_object(obj)
         self.__dropped = False
+        _ = self.mem_allocated  # cache allocated property
 
     def __repr__(self) -> str:
         addr = self._pyobject.address
@@ -181,7 +183,7 @@ class View(BaseView[_T, _KT, _VT]):
         """Memory size of the object in bytes."""
         return self._pyobject.mem_size
 
-    @property
+    @cached_property
     def mem_allocated(self) -> int:
         """Memory allocated for the object in bytes."""
         return align_size(self.mem_size)

--- a/src/einspect/views/view_tuple.py
+++ b/src/einspect/views/view_tuple.py
@@ -1,75 +1,156 @@
 from __future__ import annotations
 
-import ctypes
-from ctypes import Array
-from typing import TypeVar, overload
+from collections.abc import MutableSequence
+from ctypes import Array, addressof, c_void_p, memmove, sizeof
+from typing import SupportsIndex, TypeVar, overload
 
-from einspect.api import Py_ssize_t
-from einspect.errors import UnsafeIndexError
+from einspect.errors import UnsafeError
 from einspect.structs import PyObject, PyTupleObject
 from einspect.types import ptr
-from einspect.utils import new_ref
 from einspect.views.unsafe import unsafe
 from einspect.views.view_base import VarView
 
 __all__ = ("TupleView",)
 
-_VT = TypeVar("_VT")
+_T = TypeVar("_T")
 
 
-class TupleView(VarView[tuple, None, _VT]):
-    _pyobject: PyTupleObject[_VT]
+def can_resize(view: TupleView, target: int) -> bool:
+    """Check if the tuple can be resized to `target` length."""
+    if target <= view.size:
+        return True
 
-    @overload
-    def __getitem__(self, index: int) -> _VT:
-        ...
+    current_size = view.mem_size
+    delta = (target - view.size) * sizeof(c_void_p)
+    return current_size + delta <= view.mem_allocated
 
-    @overload
-    def __getitem__(self, index: slice) -> tuple[_VT]:
-        ...
 
-    def __getitem__(self, index: int | slice) -> _VT | tuple[_VT]:
-        if isinstance(index, int):
-            # First use api GetItem
-            try:
-                ptr = self._pyobject.GetItem(index)
-                py_struct = ptr.contents
-                return py_struct.into_object()
-            except IndexError as err:
-                raise IndexError(f"Index {index} out of range") from err
-        elif isinstance(index, slice):
-            start = index.start if index.start is not None else 0
-            stop = index.stop if index.stop is not None else self.size
-            ptr = self._pyobject.GetSlice(start, stop)
-            return ptr.contents.into_object()
-        else:
-            raise TypeError(f"Invalid index type: {type(index)}")
-
-    def __setitem__(self, index: int, value: _VT) -> None:
-        if isinstance(index, slice):
-            raise ValueError("Cannot set slice of tuple")
-        try:
-            ref = PyObject.from_object(value).as_ref()
-            self.item[index] = ref
-        except IndexError as err:
-            if not self._unsafe:
-                raise UnsafeIndexError(
-                    "Setting indices beyond current size requires entering an unsafe context."
-                ) from err
-            else:
-                if index < 0:
-                    raise IndexError(f"Index {index} out of range") from err
-
-                # If unsafe, use direct set by creating a new array
-                # noinspection PyProtectedMember
-                start_addr = ctypes.addressof(self._pyobject._ob_item_0)
-                # Size should be higher of the current size and the index
-                size = max(self.size, index + 1)
-                arr = (Py_ssize_t * size).from_address(start_addr)
-                arr[index] = new_ref(value)
+class TupleView(VarView[tuple, None, _T], MutableSequence):
+    _pyobject: PyTupleObject[_T]
 
     def __len__(self) -> int:
         return self.size
+
+    @overload
+    def __getitem__(self, index: SupportsIndex) -> _T:
+        ...
+
+    @overload
+    def __getitem__(self, index: slice) -> tuple[_T]:
+        ...
+
+    def __getitem__(self, index: SupportsIndex | slice) -> _T | tuple[_T]:
+        if isinstance(index, slice):
+            start = index.start if index.start is not None else 0
+            stop = index.stop if index.stop is not None else self.size
+            ref = self._pyobject.GetSlice(start, stop)
+            return ref.contents.into_object()
+        else:
+            index = index.__index__()
+            ob_size = self._pyobject.ob_size
+            pos_index = index if index >= 0 else ob_size + index
+            py_obj = self._pyobject.GetItem(pos_index).contents
+            return py_obj.into_object()
+
+    def __setitem__(self, index: SupportsIndex | slice, value: _T) -> None:
+        if isinstance(index, slice):
+            # Use a temp list for the slice calculation
+            temp = list(self)
+            temp[index] = value
+            # Check the size diff
+            diff = len(temp) - self.size
+
+            # Try to resize
+            if not can_resize(self, self.size + diff) and not self._unsafe:
+                raise UnsafeError(
+                    "setting slice required tuple to be resized beyond current memory allocation."
+                    " Enter an unsafe context to allow this."
+                )
+            self._pyobject.ob_size = len(temp)
+            # Set the items
+            for i, item in enumerate(temp):
+                self[i] = item
+        else:
+            index = index.__index__()
+            obj = PyObject.from_object(value)
+            obj.IncRef()
+            self.item[index] = obj.as_ref()
+
+    @overload
+    def __delitem__(self, index: SupportsIndex) -> None:
+        ...
+
+    @overload
+    def __delitem__(self, index: slice) -> None:
+        ...
+
+    def __delitem__(self, index: SupportsIndex | slice) -> None:
+        if isinstance(index, slice):
+            r = range(self.size)[index]
+            for i in reversed(r):
+                del self[i]
+        else:
+            index = index.__index__()
+            ob_size = self._pyobject.ob_size
+            # Check index
+            pos_index = index if index >= 0 else ob_size + index
+            if pos_index >= ob_size:
+                raise IndexError("tuple assignment index out of range")
+            # Get the item to DecRef it
+            item = self._pyobject.ob_item[index]
+            if item:  # Ignore if already null pointer
+                item.contents.DecRef()
+            # Set the item to null
+            self._pyobject.ob_item[index] = ptr[PyObject]()
+            # Shift items unless this is the last item
+            if pos_index != ob_size - 1:
+                src = addressof(self._pyobject.ob_item[pos_index + 1])
+                dst = addressof(item)
+                size = (ob_size - pos_index - 1) * sizeof(c_void_p)
+                memmove(dst, src, size)
+            # Reduce size
+            self._pyobject.ob_size -= 1
+
+    def pop(self, index: SupportsIndex | None = None) -> _T:
+        """
+        Remove and return item at index (default last).
+
+        Raises IndexError if tuple is empty or index is out of range.
+        """
+        index = index.__index__() if index is not None else -1
+        if self.size == 0:
+            raise IndexError("pop from empty tuple")
+        try:
+            return super().pop(index)
+        except IndexError:
+            raise IndexError("pop index out of range") from None
+
+    def insert(self, index: SupportsIndex, value: _T) -> None:
+        """Insert object before index."""
+        index = index.__index__()
+        # Normalize index
+        ob_size = self._pyobject.ob_size
+        pos_index = index if index >= 0 else ob_size + index
+        # If below 0, use 0, if above size, use size
+        norm_index = max(0, min(pos_index, ob_size))
+
+        # Resize
+        if not can_resize(self, self.size + 1) and not self._unsafe:
+            raise UnsafeError(
+                "insert required tuple to be resized beyond current memory allocation."
+                " Enter an unsafe context to allow this."
+            )
+        self._pyobject.ob_size += 1
+
+        # Shift items unless this is the last item
+        if norm_index != ob_size:
+            src = addressof(self._pyobject.ob_item[norm_index])
+            dst = src + sizeof(c_void_p)
+            size = (ob_size - norm_index) * sizeof(c_void_p)
+            memmove(dst, src, size)
+
+        # Set the item
+        self._pyobject.ob_item[norm_index] = PyObject.from_object(value).as_ref()
 
     @property
     def item(self) -> Array[ptr[PyObject]]:


### PR DESCRIPTION
Added methods for TupleView:
- `__delitem__` (index / slice)
- `__setitem__` (index / slice)
- append
- clear
- extend
- insert
- pop
- remove
- reverse

These new methods will not require an unsafe context normally as they check the allocated memory bounds before any resize operation. If resizing will be beyond allocated memory for the tuple, an `UnsafeError` is raised.

An unsafe context can be entered to bypass this allocated memory check.