### PR TITLE
Add Py.Mem api methods (Malloc, Calloc, Realloc), Simplify PyUnicode field access

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
 project = "einspect"
 copyright = "2023, Ionite"
 author = "Ionite"
-release = "v0.4.7"
+release = "v0.4.8"
 
 
 # -- General configuration ---------------------------------------------------

--- a/poetry.lock
+++ b/poetry.lock
@@ -1555,7 +1555,7 @@ lint = ["docutils-stubs", "flake8 (>=3.5.0)", "flake8-bugbear", "flake8-comprehe
 test = ["cython", "html5lib", "pytest (>=4.6)", "typed_ast"]
 
 [[package]]
-name = "sphinx-autodoc-typehints"
+name = "sphinx_autodoc_typehints"
 version = "1.23.4"
 description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
 category = "dev"
@@ -2809,7 +2809,7 @@ Sphinx = [
     {file = "Sphinx-5.3.0.tar.gz", hash = "sha256:51026de0a9ff9fc13c05d74913ad66047e104f56a129ff73e174eb5c3ee794b5"},
     {file = "sphinx-5.3.0-py3-none-any.whl", hash = "sha256:060ca5c9f7ba57a08a1219e547b269fadf125ae25b06b9fa7f66768efb652d6d"},
 ]
-sphinx-autodoc-typehints = [
+sphinx_autodoc_typehints = [
     {file = "sphinx_autodoc_typehints-1.23.4-py3-none-any.whl", hash = "sha256:46a98ee116e42ccdfe683bfc17a5cdce319b8b77f32e2bffe9c0cdad91acae32"},
     {file = "sphinx_autodoc_typehints-1.23.4.tar.gz", hash = "sha256:b47c3a690d101a259d9aa920cc57c7ea79fb705d796c0d57cb17e99bd1d80a34"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,8 @@ sphinx-autodoc-typehints = "^1.23.4"
 [tool.coverage.report]
 exclude_lines = [
     "pragma: no cover",
-    "@overload"
+    "@overload",
+    "@abstractmethod",
 ]
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.poetry]
 name = "einspect"
 version = "0.4.7"
+packages = [{ include = "einspect", from = "src" }]
 description = "Extended Inspect - view and modify memory structs of runtime objects."
 authors = ["ionite34 <dev@ionite.io>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "einspect"
-version = "0.4.7"
+version = "0.4.8"
 packages = [{ include = "einspect", from = "src" }]
 description = "Extended Inspect - view and modify memory structs of runtime objects."
 authors = ["ionite34 <dev@ionite.io>"]

--- a/src/einspect/__init__.py
+++ b/src/einspect/__init__.py
@@ -9,6 +9,6 @@ from einspect.views.view_type import impl
 
 __all__ = ("view", "unsafe", "impl", "orig")
 
-__version__ = "0.4.7"
+__version__ = "0.4.8"
 
 unsafe: ContextManager[None] = global_unsafe

--- a/src/einspect/api.py
+++ b/src/einspect/api.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import ctypes
-import typing
 from collections.abc import Sequence
 from ctypes import POINTER, Array, c_size_t, c_void_p, py_object, pythonapi, sizeof
 from typing import Callable, Type, TypeVar, Union
@@ -195,9 +194,11 @@ def align_size(size: int, alignment: int = ALIGNMENT) -> int:
     return (size + alignment - 1) & ~(alignment - 1)
 
 
-def seq_to_array(seq: Sequence[_T] | Array[_T], dtype: _SimpleCData) -> Array:
+def seq_to_array(
+    seq: Sequence[_T] | Array[_T], dtype: Type[c_void_p | _SimpleCData]
+) -> Array[_T]:
     """Cast a Sequence to a ctypes.Array of a given type."""
     if isinstance(seq, Array):
         return seq
-    arr_type = typing.cast(Type[Array[_T]], dtype * len(seq))
+    arr_type = dtype * len(seq)
     return arr_type(*seq)

--- a/src/einspect/api.py
+++ b/src/einspect/api.py
@@ -1,9 +1,14 @@
 """CPython API Methods and intrinsic constants."""
+from __future__ import annotations
+
 import ctypes
-from ctypes import POINTER, c_void_p, py_object, pythonapi, sizeof
-from typing import Callable, Union
+import typing
+from collections.abc import Sequence
+from ctypes import POINTER, Array, c_void_p, py_object, pythonapi, sizeof
+from typing import Callable, Type, TypeVar, Union
 
 import _ctypes
+from _ctypes import _SimpleCData
 
 from einspect.compat import Version, python_req
 from einspect.protocols.delayed_bind import bind_api
@@ -18,6 +23,8 @@ __all__ = (
     "ALIGNMENT_SHIFT",
     "align_size",
 )
+
+_T = TypeVar("_T")
 
 Py_ssize_t = ctypes.c_ssize_t
 """Constant for type Py_ssize_t."""
@@ -136,3 +143,11 @@ PyObj_FromPtr: Callable[[IntSize], object] = _ctypes.PyObj_FromPtr
 def align_size(size: int, alignment: int = ALIGNMENT) -> int:
     """Align size to alignment."""
     return (size + alignment - 1) & ~(alignment - 1)
+
+
+def seq_to_array(seq: Sequence[_T] | Array[_T], dtype: _SimpleCData) -> Array:
+    """Cast a Sequence to a ctypes.Array of a given type."""
+    if isinstance(seq, Array):
+        return seq
+    arr_type = typing.cast(Type[Array[_T]], dtype * len(seq))
+    return arr_type(*seq)

--- a/src/einspect/api.py
+++ b/src/einspect/api.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 import ctypes
 from collections.abc import Sequence
 from ctypes import POINTER, Array, c_size_t, c_void_p, py_object, pythonapi, sizeof
-from typing import Callable, Type, TypeVar, Union
+from typing import Callable, TypeVar, Union
 
 import _ctypes
-from _ctypes import _SimpleCData
 from typing_extensions import Annotated
 
 from einspect.compat import Version, python_req
@@ -25,6 +24,7 @@ __all__ = (
 )
 
 _T = TypeVar("_T")
+_CT = TypeVar("_CT")
 
 Py_ssize_t = ctypes.c_ssize_t
 """Constant for type Py_ssize_t."""
@@ -194,9 +194,7 @@ def align_size(size: int, alignment: int = ALIGNMENT) -> int:
     return (size + alignment - 1) & ~(alignment - 1)
 
 
-def seq_to_array(
-    seq: Sequence[_T] | Array[_T], dtype: Type[c_void_p | _SimpleCData]
-) -> Array[_T]:
+def seq_to_array(seq: Sequence[_T] | Array[_T], dtype: type[_CT]) -> Array[_CT]:
     """Cast a Sequence to a ctypes.Array of a given type."""
     if isinstance(seq, Array):
         return seq

--- a/src/einspect/compat.py
+++ b/src/einspect/compat.py
@@ -50,7 +50,6 @@ _V = TypeVar("_V", bound=Version)
 
 @dataclass
 class RequiresPythonVersion(Generic[_V]):
-    __slots__ = ("version",)
     version: _V
 
     def __msg__(self) -> str:

--- a/src/einspect/compat.py
+++ b/src/einspect/compat.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Generic, NoReturn, TypeVar
 
-__all__ = ("Version", "RequiresPythonVersion", "python_req", "python_above", "abc")
+__all__ = ("Version", "RequiresPythonVersion", "python_req", "abc")
 
 if sys.version_info > (3, 8):
     abc = typing  # noqa: F401, F811
@@ -21,6 +21,20 @@ class Version(Enum):
     PY_3_8 = (3, 8)
     PY_3_9 = (3, 9)
     PY_3_10 = (3, 10)
+    PY_3_11 = (3, 11)
+    PY_3_12 = (3, 12)
+
+    def above(self, or_eq: bool = True) -> bool:
+        """Return whether the current version is above this version."""
+        if or_eq:
+            return sys.version_info >= self.value
+        return sys.version_info > self.value
+
+    def below(self, or_eq: bool = True) -> bool:
+        """Return whether the current version is below this version."""
+        if or_eq:
+            return sys.version_info <= self.value
+        return sys.version_info < self.value
 
 
 _V = TypeVar("_V", bound=Version)
@@ -48,8 +62,3 @@ def python_req(version: _V) -> RequiresPythonVersion[_V] | None:
     if sys.version_info < version.value:  # type: ignore
         return RequiresPythonVersion(version)
     return None
-
-
-def python_above(version: Version) -> bool:
-    """Returns True if equal or greater than current Python version."""
-    return sys.version_info >= version.value

--- a/src/einspect/structs/py_long.py
+++ b/src/einspect/structs/py_long.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import ctypes
 from collections.abc import Sequence
-from ctypes import c_uint32
+from ctypes import addressof, c_uint32, sizeof
 
 from typing_extensions import Annotated
 
+from einspect.api import seq_to_array
 from einspect.structs.deco import struct
 from einspect.structs.py_object import Fields, PyVarObject
 from einspect.types import Array
@@ -46,14 +47,11 @@ class PyLongObject(PyVarObject[int, None, None]):
 
     @ob_digit.setter
     def ob_digit(self, value: Array[int | c_uint32] | Sequence[int]) -> None:
-        if not isinstance(value, Array):
-            arr = (c_uint32 * len(value))()
-            arr[:] = value
-            value = arr
+        arr = seq_to_array(value, c_uint32)
         ctypes.memmove(
-            ctypes.addressof(self._ob_digit_0),
-            ctypes.addressof(value),
-            ctypes.sizeof(value),
+            addressof(self._ob_digit_0),
+            addressof(arr),
+            sizeof(arr),
         )
 
     @property

--- a/src/einspect/structs/py_tuple.py
+++ b/src/einspect/structs/py_tuple.py
@@ -23,6 +23,7 @@ class PyTupleObject(PyVarObject[tuple, None, _VT]):
     """
 
     # Size of this array is only known after creation
+    # this field just serves to get the address of the array
     _ob_item_0: ptr[PyObject] * 0
 
     def _format_fields_(self) -> Fields:

--- a/src/einspect/structs/py_unicode.py
+++ b/src/einspect/structs/py_unicode.py
@@ -1,7 +1,18 @@
 from __future__ import annotations
 
-import ctypes
-from ctypes import POINTER, c_int64, c_uint, c_uint8, c_uint16, c_uint32, c_wchar
+from ctypes import (
+    Union,
+    addressof,
+    c_char,
+    c_char_p,
+    c_int64,
+    c_uint,
+    c_uint8,
+    c_uint16,
+    c_uint32,
+    c_void_p,
+    c_wchar,
+)
 from enum import IntEnum
 from typing import Type
 
@@ -9,7 +20,7 @@ from typing_extensions import Annotated
 
 from einspect.structs.deco import struct
 from einspect.structs.py_object import PyObject
-from einspect.types import Array
+from einspect.types import Array, ptr
 
 
 class State(IntEnum):
@@ -40,11 +51,11 @@ class Kind(IntEnum):
 
 
 @struct
-class LegacyUnion(ctypes.Union):
-    any: ctypes.c_void_p
-    latin1: ctypes.POINTER(ctypes.c_uint8)  # Py_UCS1
-    ucs2: ctypes.POINTER(ctypes.c_uint16)  # Py_UCS2
-    ucs4: ctypes.POINTER(ctypes.c_uint32)  # Py_UCS4
+class LegacyUnion(Union):
+    any: c_void_p
+    latin1: ptr[c_uint8]  # Py_UCS1
+    ucs2: ptr[c_uint16]  # Py_UCS2
+    ucs4: ptr[c_uint32]  # Py_UCS4
 
 
 @struct
@@ -61,10 +72,10 @@ class PyUnicodeObject(PyObject):
     ascii: Annotated[int, c_uint, 1]
     ready: Annotated[int, c_uint, 1]
     padding: Annotated[int, c_uint, 24]
-    wstr: POINTER(ctypes.c_wchar)
+    wstr: ptr[c_wchar]
     # Fields after this do not exist if ascii
     utf8_length: int
-    utf8: ctypes.c_char_p
+    utf8: c_char_p
     wstr_length: int
     # Fields after this do not exist if compact
     data: LegacyUnion
@@ -72,7 +83,7 @@ class PyUnicodeObject(PyObject):
     @property
     def buffer(self) -> Array:
         cls = type(self)
-        addr = ctypes.addressof(self)
+        addr = addressof(self)
 
         # Annotate some types transformed by ctypes.Structure
         data_offset: int = cls.data.offset  # type: ignore
@@ -83,7 +94,7 @@ class PyUnicodeObject(PyObject):
             subtype = Kind(self.kind).type_info()
             if self.ascii:
                 # ASCII buffer comes right after wstr
-                subtype = ctypes.c_char
+                subtype = c_char
                 addr += utf8_length_offset
             else:
                 # UCS1/2/4 buffer comes right after wstr

--- a/src/einspect/structs/py_unicode.py
+++ b/src/einspect/structs/py_unicode.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import ctypes
-from ctypes import POINTER, Array, c_int64, c_uint
+from ctypes import POINTER, c_int64, c_uint, c_uint8, c_uint16, c_uint32, c_wchar
 from enum import IntEnum
+from typing import Type
 
 from typing_extensions import Annotated
 
 from einspect.structs.deco import struct
 from einspect.structs.py_object import PyObject
+from einspect.types import Array
 
 
 class State(IntEnum):
@@ -27,14 +29,14 @@ class Kind(IntEnum):
     PyUnicode_2BYTE = 2
     PyUnicode_4BYTE = 4
 
-    def type(self):
+    def type(self) -> Type[c_wchar | c_uint8 | c_uint16 | c_uint32]:
         types_map = {
-            self.PyUnicode_WCHAR: ctypes.c_wchar,
-            self.PyUnicode_1BYTE: ctypes.c_uint8,
-            self.PyUnicode_2BYTE: ctypes.c_uint16,
-            self.PyUnicode_4BYTE: ctypes.c_uint32,
+            0: c_wchar,
+            1: c_uint8,
+            2: c_uint16,
+            4: c_uint32,
         }
-        return types_map[self]
+        return types_map[int(self)]
 
 
 @struct

--- a/src/einspect/types.py
+++ b/src/einspect/types.py
@@ -9,7 +9,7 @@ from typing_extensions import Self
 
 __all__ = ("ptr", "Array", "_SelfPtr")
 
-from einspect.compat import Version, python_above
+from einspect.compat import Version
 
 _T = TypeVar("_T")
 
@@ -50,7 +50,7 @@ class _Ptr(_Pointer):
             raise TypeError(f"{e} (During POINTER({item}))") from e
 
 
-if python_above(Version.PY_3_9):  # pragma: no cover
+if Version.PY_3_9.above():  # pragma: no cover
     # This cannot be defined in 3.8 as ctypes.Array doesn't support subscripting
     class Array(ctypes.Array[_T]):
         """

--- a/src/einspect/views/view_base.py
+++ b/src/einspect/views/view_base.py
@@ -18,7 +18,7 @@ from einspect.errors import (
     UnsafeAttributeError,
     UnsafeError,
 )
-from einspect.structs import PyObject, PyVarObject
+from einspect.structs import PyObject, PyTypeObject, PyVarObject
 from einspect.views._display import Formatter
 from einspect.views.unsafe import UnsafeContext, unsafe
 
@@ -112,10 +112,9 @@ class View(BaseView[_T, _KT, _VT]):
         return self._pyobject.ob_type.contents.into_object()
 
     @type.setter
-    def type(self, value: type) -> None:
-        if not self._unsafe:
-            raise UnsafeAttributeError.from_attr("type")
-        self._pyobject.ob_type = value
+    @unsafe
+    def type(self, value: Type) -> None:
+        self._pyobject.ob_type = PyTypeObject.from_object(value).as_ref()
 
     @property
     def base(self) -> _T:

--- a/src/einspect/views/view_int.py
+++ b/src/einspect/views/view_int.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from ctypes import Array, c_uint32
 from typing import Iterable, TypeVar
 
+from typing_extensions import Annotated
+
 from einspect.structs import PyLongObject
 from einspect.views.view_base import VarView
 
@@ -15,7 +17,7 @@ class IntView(VarView[int, None, None]):
     _pyobject: PyLongObject
 
     @property
-    def digits(self) -> Array[c_uint32]:
+    def digits(self) -> Array[Annotated[int, c_uint32]]:
         return self._pyobject.ob_digit
 
     @digits.setter

--- a/src/einspect/views/view_tuple.py
+++ b/src/einspect/views/view_tuple.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import MutableSequence
+from collections.abc import MutableSequence, Sequence
 from ctypes import Array, addressof, c_void_p, memmove, sizeof
 from typing import SupportsIndex, TypeVar, overload
 
@@ -153,12 +153,16 @@ class TupleView(VarView[tuple, None, _T], MutableSequence):
         self._pyobject.ob_item[norm_index] = PyObject.from_object(value).as_ref()
 
     @property
-    def item(self) -> Array[ptr[PyObject]]:
-        """The array of PyObject pointers."""
+    def item(self) -> Array[ptr[PyObject[_T]]]:
+        """The `ob_item` array of PyObject pointers."""
         return self._pyobject.ob_item
 
     @item.setter
     @unsafe
-    def item(self, value: Array[ptr[PyObject]]) -> None:
-        """Set the array of PyObject pointers."""
+    def item(
+        self, value: Array[ptr[PyObject]] | Sequence[ptr[PyObject]] | Sequence[object]
+    ) -> None:
+        """Set the `ob_item` array of PyObject pointers."""
+        if not isinstance(value, Array):
+            value = [PyObject.try_from(v).with_ref().as_ref() for v in value]
         self._pyobject.ob_item = value

--- a/src/einspect/views/view_type.py
+++ b/src/einspect/views/view_type.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Type, TypeVar
 
 from typing_extensions import Self
 
-from einspect.compat import Version, python_above
+from einspect.compat import Version
 from einspect.errors import UnsafeError
 from einspect.structs.include.object_h import TpFlags
 from einspect.structs.py_type import PyTypeObject
@@ -51,14 +51,14 @@ class TypeView(VarView[_T, None, None]):
     @property
     def immutable(self) -> bool:
         """Return True if the type is immutable."""
-        if python_above(Version.PY_3_10):
+        if Version.PY_3_10.above():
             return bool(self._pyobject.tp_flags & TpFlags.IMMUTABLETYPE)
         return not bool(self._pyobject.tp_flags & TpFlags.HEAPTYPE)
 
     @immutable.setter
     def immutable(self, value: bool):
         """Set whether the type is immutable."""
-        if python_above(Version.PY_3_10):
+        if Version.PY_3_10.above():
             if value:
                 self._pyobject.tp_flags |= TpFlags.IMMUTABLETYPE
             else:
@@ -110,6 +110,10 @@ class TypeView(VarView[_T, None, None]):
 
         with self.as_mutable():
             self._pyobject.setattr_safe(key, value)
+
+    # <-- Begin Managed::Properties (structs::py_type.PyTypeObject) -->
+
+    # <-- End Managed::Properties -->
 
     def __getattr__(self, item: str):
         # Forward `tp_` attributes from PyTypeObject

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -187,6 +187,17 @@ class TestPyLongObject:
             obj.ob_digit = (i for i in range(5))
 
 
+class TestPyTupleObject:
+    def test_item(self):
+        obj = st.PyTupleObject(
+            ob_refcnt=1,
+            ob_type=st.PyTypeObject.from_object(tuple).as_ref(),
+            ob_size=1,
+        )
+        obj.ob_item = [st.PyObject.from_object(17).as_ref()]
+        assert obj.into_object() == (17,)
+
+
 @pytest.mark.parametrize(
     ["obj", "struct", "size"],
     [

--- a/tests/test_unsafe.py
+++ b/tests/test_unsafe.py
@@ -13,3 +13,14 @@ def test_unsafe_error():
         v.ref_count = 0
     # setter should not have run
     assert v.ref_count == current
+
+
+def test_change_type():
+    x = 2**28 + 5
+    v = view(x)
+    assert v.type is int
+    with v.unsafe() as v:
+        v.type = bool
+
+    assert isinstance(x, bool)
+    assert x - 5 == 2**28

--- a/tests/test_unsafe.py
+++ b/tests/test_unsafe.py
@@ -15,12 +15,14 @@ def test_unsafe_error():
     assert v.ref_count == current
 
 
+@pytest.mark.run_in_subprocess
 def test_change_type():
     x = 2**28 + 5
     v = view(x)
     assert v.type is int
     with v.unsafe() as v:
         v.type = bool
-
-    assert isinstance(x, bool)
-    assert x - 5 == 2**28
+        assert isinstance(x, bool)
+        assert x - 5 == 2**28
+        v.type = int
+        assert isinstance(x, int)


### PR DESCRIPTION
Added:
- Py.Mem api methods (Malloc, Calloc, Realloc)
- Add try_from and with_ref methods to PyObject

Fixes and Enhancements:
- Simplify PyUnicode field access