### PR TITLE
Implement MutableSequence for StrView

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ PyListObject(at 0x2833738):
 ```
 
 [doc_tuple_view]: https://docs.ionite.io/einspect/api/views/view_tuple.html#einspect.views.view_tuple
+[doc_str_view]: https://docs.ionite.io/einspect/api/views/view_str.html#einspect.views.view_str
 [py_doc_mutable_seq]: https://docs.python.org/3/library/stdtypes.html#mutable-sequence-types
 ## Mutate tuples, strings, ints, or other immutable types
-> [TupleView][doc_tuple_view] supports all [MutableSequence][py_doc_mutable_seq] methods (append, extend, insert, pop, remove, reverse, clear).
+> [TupleView][doc_tuple_view] and [StrView][doc_str_view] supports all [MutableSequence][py_doc_mutable_seq] methods (append, extend, insert, pop, remove, reverse, clear).
 ```python
 from einspect import view
 
@@ -65,18 +66,28 @@ print(tup)      # (1, 2)
 v.clear()
 print(tup)      # ()
 ```
-
 ```python
 from einspect import view
 
 text = "hello"
-num = 100
 
-view(text).buffer[:] = b"world"
-view(num).value = 5
+v = view(text)
+v[1] = "3"
+v[4:] = "o~"
+v.append("!")
 
-print(text)  # world
-print(num)   # 5
+print(text)  # h3llo~!
+v.reverse()
+print(text)  # !~oll3h
+```
+```python
+from einspect import view
+
+n = 500
+view(n).value = 10
+
+print(500)        # 10
+print(500 == 10)  # True
 ```
 
 ## Modify attributes of built-in types, get original attributes with `orig`

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
 project = "einspect"
 copyright = "2023, Ionite"
 author = "Ionite"
-release = "v0.4.8"
+release = "v0.4.9"
 
 
 # -- General configuration ---------------------------------------------------

--- a/poetry.lock
+++ b/poetry.lock
@@ -1479,7 +1479,7 @@ win32 = ["pywin32"]
 
 [[package]]
 name = "setuptools"
-version = "66.0.0"
+version = "66.1.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
@@ -1855,7 +1855,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.12"
-content-hash = "a152a80da8fd6e2a8be593a9643d92b0e9150cbeda2d0dcea20a0b79d8469003"
+content-hash = "564a4d2687caea148d837c8f2117288d6f3734515c81eea39d82703455e2b26e"
 
 [metadata.files]
 alabaster = [
@@ -2786,8 +2786,8 @@ Send2Trash = [
     {file = "Send2Trash-1.8.0.tar.gz", hash = "sha256:d2c24762fd3759860a0aff155e45871447ea58d2be6bdd39b5c8f966a0c99c2d"},
 ]
 setuptools = [
-    {file = "setuptools-66.0.0-py3-none-any.whl", hash = "sha256:a78d01d1e2c175c474884671dde039962c9d74c7223db7369771fcf6e29ceeab"},
-    {file = "setuptools-66.0.0.tar.gz", hash = "sha256:bd6eb2d6722568de6d14b87c44a96fac54b2a45ff5e940e639979a3d1792adb6"},
+    {file = "setuptools-66.1.1-py3-none-any.whl", hash = "sha256:6f590d76b713d5de4e49fe4fbca24474469f53c83632d5d0fd056f7ff7e8112b"},
+    {file = "setuptools-66.1.1.tar.gz", hash = "sha256:ac4008d396bc9cd983ea483cb7139c0240a07bbc74ffb6232fceffedc6cf03a8"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "einspect"
-version = "0.4.8"
+version = "0.4.9"
 packages = [{ include = "einspect", from = "src" }]
 description = "Extended Inspect - view and modify memory structs of runtime objects."
 authors = ["ionite34 <dev@ionite.io>"]
@@ -48,9 +48,11 @@ pre-commit = "^2.20.0"
 flake8 = { version = "^6.0.0", python = ">= 3.8.1" }
 flake8-print = { version = "^5.0.0", python = ">= 3.8.1" }
 
+[tool.poetry.group.tools.dependencies]
+rich = "^12.6.0"
+
 [tool.poetry.group.dev-extras.dependencies]
 jupyter = "^1.0.0"
-rich = "^12.6.0"
 
 [tool.poetry.group.ci.dependencies]
 typing-extensions = "^4.4.0"

--- a/src/einspect/__init__.py
+++ b/src/einspect/__init__.py
@@ -9,6 +9,6 @@ from einspect.views.view_type import impl
 
 __all__ = ("view", "unsafe", "impl", "orig")
 
-__version__ = "0.4.8"
+__version__ = "0.4.9"
 
 unsafe: ContextManager[None] = global_unsafe

--- a/src/einspect/structs/py_object.py
+++ b/src/einspect/structs/py_object.py
@@ -23,6 +23,7 @@ Fields = Dict[str, Union[str, Tuple[str, Type]]]
 _T = TypeVar("_T")
 _KT = TypeVar("_KT")
 _VT = TypeVar("_VT")
+_ST = TypeVar("_ST", bound=Structure)
 
 
 @struct
@@ -118,6 +119,10 @@ class PyObject(Structure, AsRef, Generic[_T, _KT, _VT]):
         """Cast the PyObject into a Python object."""
         py_obj = ctypes.cast(self.as_ref(), ctypes.py_object)
         return py_obj.value
+
+    def astype(self, dtype: Type[_ST]) -> _ST:
+        """Cast the PyObject into another PyObject type."""
+        return dtype.from_address(self.address)
 
     def with_ref(self, n: int = 1) -> Self:
         """Increment the reference count of the PyObject by n. Return self."""

--- a/src/einspect/structs/py_set.py
+++ b/src/einspect/structs/py_set.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ctypes import Array, Structure, pointer
+from ctypes import Structure, pointer
 from typing import Generic, TypeVar
 
 from typing_extensions import Annotated
@@ -8,6 +8,7 @@ from typing_extensions import Annotated
 from einspect.api import Py_hash_t
 from einspect.structs.deco import struct
 from einspect.structs.py_object import PyObject
+from einspect.structs.traits import AsRef
 from einspect.types import ptr
 
 _T = TypeVar("_T")
@@ -17,17 +18,13 @@ PySet_MINSIZE = 8
 
 
 @struct
-class SetEntry(Structure, Generic[_T]):
+class SetEntry(Structure, AsRef, Generic[_T]):
     key: pointer[PyObject[_T, None, None]]
     hash: Annotated[int, Py_hash_t]  # noqa: A003
 
 
-@struct(
-    fields=[
-        ("smalltable", SetEntry * PySet_MINSIZE),
-    ]
-)
-class PySetObject(PyObject[set, None, _T]):
+@struct
+class PySetObject(PyObject[set, None, _T], AsRef):
     """
     Defines a PySetObject Structure.
 
@@ -40,7 +37,7 @@ class PySetObject(PyObject[set, None, _T]):
     table: ptr[SetEntry[_T]]
     hash: Annotated[int, Py_hash_t]  # noqa: A003
     finger: int
-    smalltable: Array[SetEntry[_T]]
+    smalltable: SetEntry * PySet_MINSIZE
     weakreflist: ptr[PyObject]
 
     @classmethod

--- a/src/einspect/structs/py_set.py
+++ b/src/einspect/structs/py_set.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ctypes import Structure, pointer
+from ctypes import Structure
 from typing import Generic, TypeVar
 
 from typing_extensions import Annotated
@@ -19,7 +19,7 @@ PySet_MINSIZE = 8
 
 @struct
 class SetEntry(Structure, AsRef, Generic[_T]):
-    key: pointer[PyObject[_T, None, None]]
+    key: ptr[PyObject[_T, None, None]]
     hash: Annotated[int, Py_hash_t]  # noqa: A003
 
 

--- a/src/einspect/structs/py_unicode.py
+++ b/src/einspect/structs/py_unicode.py
@@ -12,18 +12,87 @@ from ctypes import (
     c_uint32,
     c_void_p,
     c_wchar,
+    c_wchar_p,
+    cast,
+    pythonapi,
+    sizeof,
 )
 from enum import IntEnum
 from typing import Type
 
 from typing_extensions import Annotated
 
+from einspect.protocols import bind_api
 from einspect.structs.deco import struct
 from einspect.structs.py_object import PyObject
 from einspect.types import Array, ptr
 
 
+def _PyUnicode_UTF8(obj: PyASCIIObject) -> c_char_p:
+    return obj.astype(PyCompactUnicodeObject).utf8
+
+
+def _PyUnicode_COMPACT_DATA(obj: PyASCIIObject) -> c_void_p:
+    """Return a void pointer to the raw unicode buffer."""
+    if obj.ascii:
+        end = obj.address + sizeof(PyASCIIObject)
+        return cast(end, c_void_p)
+    return cast(obj.astype(PyCompactUnicodeObject).address + 1, c_void_p)
+
+
+def _PyUnicode_NONCOMPACT_DATA(obj: PyASCIIObject) -> c_void_p:
+    assert not obj.compact
+    data = obj.astype(PyUnicodeObject).data.any
+    assert data
+    return data
+
+
+def PyUnicode_DATA(obj: PyASCIIObject) -> c_void_p:
+    if obj.compact:
+        return _PyUnicode_COMPACT_DATA(obj)
+    return _PyUnicode_NONCOMPACT_DATA(obj)
+
+
+def PyUnicode_IS_COMPACT_ASCII(obj: PyASCIIObject) -> bool:
+    return bool(obj.compact & obj.ascii)
+
+
+def _PyUnicode_HAS_UTF8_MEMORY(obj: PyASCIIObject) -> bool:
+    return (
+        not PyUnicode_IS_COMPACT_ASCII(obj)
+        and _PyUnicode_UTF8(obj)
+        and cast(_PyUnicode_UTF8(obj), c_void_p) != PyUnicode_DATA(obj)
+    )
+
+
+def _PyUnicode_UTF8_LENGTH(obj):
+    return obj.astype(PyCompactUnicodeObject).utf8_length
+
+
+def PyUnicode_UTF8_LENGTH(obj: PyASCIIObject) -> int:
+    assert obj.ready
+    if PyUnicode_IS_COMPACT_ASCII(obj):
+        return obj.length
+    return _PyUnicode_UTF8_LENGTH(obj)
+
+
+def _PyUnicode_HAS_WSTR_MEMORY(obj: PyASCIIObject) -> bool:
+    """Return True if the unicode object has an allocated wstr memory block."""
+    return obj.wstr and (
+        not obj.ready
+        or addressof(cast(obj.wstr, c_void_p)) != addressof(PyUnicode_DATA(obj))
+    )
+
+
+def PyUnicode_WSTR_LENGTH(obj: PyASCIIObject) -> int:
+    if PyUnicode_IS_COMPACT_ASCII(obj):
+        return obj.length
+    return obj.astype(PyCompactUnicodeObject).wstr_length
+
+
 class State(IntEnum):
+    """State of the string object (SSTATE constants)."""
+
     NOT_INTERNED = 0
     INTERNED_MORTAL = 1
     INTERNED_IMMORTAL = 2
@@ -59,7 +128,7 @@ class LegacyUnion(Union):
 
 
 @struct
-class PyUnicodeObject(PyObject):
+class PyASCIIObject(PyObject[str, None, None]):
     """
     Defines a PyUnicodeObject Structure
     """
@@ -72,22 +141,41 @@ class PyUnicodeObject(PyObject):
     ascii: Annotated[int, c_uint, 1]
     ready: Annotated[int, c_uint, 1]
     padding: Annotated[int, c_uint, 24]
-    wstr: ptr[c_wchar]
-    # Fields after this do not exist if ascii
-    utf8_length: int
-    utf8: c_char_p
-    wstr_length: int
-    # Fields after this do not exist if compact
-    data: LegacyUnion
+    wstr: c_wchar_p
+
+    @property
+    def mem_size(self) -> int:
+        """
+        Return the size of the memory allocated for the string.
+
+        Should match `unicode_sizeof_impl`
+        https://github.com/python/cpython/blob/3.11/Objects/unicodeobject.c#L14120-L14149
+        """
+        if self.compact and self.ascii:
+            size = sizeof(PyASCIIObject) + self.length + 1
+        elif self.compact:
+            size = sizeof(PyCompactUnicodeObject) + (self.length + 1) * Kind(self.kind)
+        else:
+            # If it is a two-block object, account for base object, and
+            # for character block if present.
+            size = sizeof(PyUnicodeObject)
+            if self.astype(PyUnicodeObject).data.any:
+                size += self.length * Kind(self.kind)
+
+        # If the wstr pointer is present, account for it unless it is shared
+        # with the data pointer. Check if the data is not shared.
+        if _PyUnicode_HAS_WSTR_MEMORY(self):
+            size += (PyUnicode_WSTR_LENGTH(self) + 1) * sizeof(c_wchar)
+        if _PyUnicode_HAS_UTF8_MEMORY(self):
+            size += PyUnicode_UTF8_LENGTH(self) + 1
+
+        return size
 
     @property
     def buffer(self) -> Array:
-        cls = type(self)
+        utf8_length_offset: int = PyUnicodeObject.utf8_length.offset  # type: ignore
+        data_offset: int = PyUnicodeObject.data.offset  # type: ignore
         addr = addressof(self)
-
-        # Annotate some types transformed by ctypes.Structure
-        data_offset: int = cls.data.offset  # type: ignore
-        utf8_length_offset: int = cls.utf8_length.offset  # type: ignore
 
         if self.compact:
             # Get the str subtype type mapping
@@ -112,3 +200,33 @@ class PyUnicodeObject(PyObject):
             return self.data.ucs4  # type: ignore
 
         raise ValueError(f"Unknown kind: {self.kind}")
+
+    @bind_api(pythonapi["PyUnicode_Substring"])
+    def Substring(self, start: int, end: int) -> PyUnicodeObject:
+        """
+        Return a substring from index start to character index end (excluded).
+
+        Negative indices are not supported.
+        """
+
+
+@struct
+class PyCompactUnicodeObject(PyASCIIObject):
+    """
+    Defines a PyCompactUnicodeObject Structure
+
+    Non-ASCII strings allocated through PyUnicode_New use the
+    PyCompactUnicodeObject structure. state.compact is set, and the data
+    immediately follow the structure.
+    """
+
+    utf8_length: int  # Number of bytes in utf8, excluding the \0
+    utf8: c_char_p  # UTF-8 representation (null-terminated)
+    wstr_length: int  # Number of characters in wstr, surrogates count as two code points
+
+
+@struct
+class PyUnicodeObject(PyCompactUnicodeObject):
+    """Defines a PyUnicodeObject Structure."""
+
+    data: LegacyUnion

--- a/src/einspect/structs/py_unicode.py
+++ b/src/einspect/structs/py_unicode.py
@@ -209,6 +209,10 @@ class PyASCIIObject(PyObject[str, None, None]):
         Negative indices are not supported.
         """
 
+    @bind_api(pythonapi["PyUnicode_GetLength"])
+    def GetLength(self) -> int:
+        """Return the length of the string in code points."""
+
 
 @struct
 class PyCompactUnicodeObject(PyASCIIObject):

--- a/src/einspect/views/_display.py
+++ b/src/einspect/views/_display.py
@@ -72,6 +72,7 @@ class Formatter:
         try:
             return DISP_TRANSFORMS[type(obj)](obj)
         except KeyError:
+            # Fallback to repr
             return repr(obj)
 
     def format_attr(

--- a/src/einspect/views/view_base.py
+++ b/src/einspect/views/view_base.py
@@ -9,7 +9,7 @@ from contextlib import ExitStack
 from copy import deepcopy
 from ctypes import py_object
 from functools import cached_property
-from typing import Final, Generic, Type, TypeVar, Union, get_args, get_type_hints
+from typing import Final, Generic, Type, TypeVar, get_args, get_type_hints
 
 from einspect.api import Py, PyObj_FromPtr, align_size
 from einspect.errors import (
@@ -72,10 +72,14 @@ class View(BaseView[_T, _KT, _VT]):
 
     def __init__(self, obj: _T, ref: bool = REF_DEFAULT) -> None:
         super().__init__(obj, ref)
+
         struct_type = get_type_hints(self.__class__)["_pyobject"]
         # For unions, use first type
-        if isinstance(struct_type, type(Union)):
+        # There's no easy way to check this in <3.9 without types.UnionType
+        # So we just check if not a PyObject / generic alias
+        if not getattr(struct_type, "from_object", None):
             struct_type = get_args(struct_type)[0]
+
         self._pyobject = struct_type.from_object(obj)
         self.__dropped = False
         _ = self.mem_allocated  # cache allocated property

--- a/src/einspect/views/view_base.py
+++ b/src/einspect/views/view_base.py
@@ -9,8 +9,7 @@ from contextlib import ExitStack
 from copy import deepcopy
 from ctypes import py_object
 from functools import cached_property
-from types import UnionType
-from typing import Final, Generic, Type, TypeVar, get_args, get_type_hints
+from typing import Final, Generic, Type, TypeVar, Union, get_args, get_type_hints
 
 from einspect.api import Py, PyObj_FromPtr, align_size
 from einspect.errors import (
@@ -75,7 +74,7 @@ class View(BaseView[_T, _KT, _VT]):
         super().__init__(obj, ref)
         struct_type = get_type_hints(self.__class__)["_pyobject"]
         # For unions, use first type
-        if isinstance(struct_type, UnionType):
+        if isinstance(struct_type, type(Union)):
             struct_type = get_args(struct_type)[0]
         self._pyobject = struct_type.from_object(obj)
         self.__dropped = False

--- a/src/einspect/views/view_set.py
+++ b/src/einspect/views/view_set.py
@@ -25,11 +25,13 @@ class SetView(View[set, None, _T]):
 
     @property
     def fill(self) -> int:
+        """Number active and dummy entries."""
         return self._pyobject.fill
 
     @fill.setter
     @unsafe
     def fill(self, value: int) -> None:
+        """Number active and dummy entries."""
         self._pyobject.fill = value
 
     @property
@@ -56,13 +58,20 @@ class SetView(View[set, None, _T]):
         arr = cast(self._pyobject.table, POINTER(SetEntry * size))
         return arr.contents
 
+    @table.setter
+    @unsafe
+    def table(self, value: Array[SetEntry[_T]]) -> None:
+        self._pyobject.table = ptr(value[0])
+
     @property
     def finger(self) -> int:
+        """Search finger for pop()"""
         return self._pyobject.finger
 
     @finger.setter
     @unsafe
     def finger(self, value: int) -> None:
+        """Set search finger for pop()"""
         self._pyobject.finger = value
 
     @property

--- a/src/einspect/views/view_str.py
+++ b/src/einspect/views/view_str.py
@@ -1,22 +1,145 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import MutableSequence
 from ctypes import Array
-from typing import TypeVar, overload
+from typing import Iterable, SupportsIndex, TypeVar, overload
 
 from einspect.api import Py_ssize_t
-from einspect.structs import PyUnicodeObject
-from einspect.structs.py_unicode import Kind, State
+from einspect.errors import UnsafeError
+from einspect.structs.py_unicode import (
+    Kind,
+    PyASCIIObject,
+    PyCompactUnicodeObject,
+    PyUnicodeObject,
+    State,
+)
 from einspect.views.unsafe import unsafe
-from einspect.views.view_base import View
+from einspect.views.view_base import REF_DEFAULT, View
 
 __all__ = ("StrView",)
 
 _T = TypeVar("_T")
 
 
-class StrView(View[str, None, None], Sequence):
-    _pyobject: PyUnicodeObject
+class StrView(View[str, None, None], MutableSequence):
+    _pyobject: PyASCIIObject | PyCompactUnicodeObject | PyUnicodeObject
+
+    def __init__(self, obj: str, ref: bool = REF_DEFAULT) -> None:
+        """View a Python string object."""
+        super().__init__(obj, ref)
+        # Start with PyASCIIObject, check if we can use a more specific type
+        self._narrow_type()
+
+    def _narrow_type(self) -> None:
+        # Narrow to a more specific unicode type if possible
+        if self._pyobject.ascii:
+            self._pyobject = self._pyobject.astype(PyASCIIObject)
+        else:
+            if self._pyobject.compact:
+                self._pyobject = self._pyobject.astype(PyCompactUnicodeObject)
+            else:
+                self._pyobject = self._pyobject.astype(PyUnicodeObject)
+
+    def __len__(self) -> int:
+        return self._pyobject.GetLength()
+
+    @overload
+    def __getitem__(self, index: int) -> str:
+        ...
+
+    @overload
+    def __getitem__(self, index: slice) -> str:
+        ...
+
+    def __getitem__(self, index: int | slice) -> str:
+        return str.__getitem__(self.base, index)
+
+    @overload
+    def __setitem__(self, index: int, value: str) -> None:
+        ...
+
+    @overload
+    def __setitem__(self, index: slice, value: Iterable[str]) -> None:
+        ...
+
+    def __setitem__(self, index: int | slice, value: str | Iterable[str]) -> None:
+        # Use a temp list for the slice calculation
+        temp = list(self._pyobject.into_object())
+        temp[index] = value
+        # Combine to str
+        target = "".join(temp)
+
+        # See if resizing is safe
+        if target.__sizeof__() > self.mem_allocated and not self._unsafe:
+            raise UnsafeError(
+                "setitem required str to be resized beyond current memory allocation."
+                " Enter an unsafe context to allow this."
+            )
+
+        # Since the struct type might change, use a memmove
+        v = StrView(target, ref=False)
+        with self.unsafe(), v.unsafe():
+            v.move_to(self)
+        self._narrow_type()
+
+        # On modifications, unintern the string
+        self._pyobject.interned = 0
+
+    @overload
+    def __delitem__(self, index: int) -> None:
+        ...
+
+    @overload
+    def __delitem__(self, index: slice) -> None:
+        ...
+
+    def __delitem__(self, index: int) -> None:
+        # Use a temp list for the slice calculation
+        temp = list(self._pyobject.into_object())
+        del temp[index]
+        # Combine to str
+        target = "".join(temp)
+
+        # See if resizing is safe
+        if target.__sizeof__() > self.mem_allocated and not self._unsafe:
+            raise UnsafeError(
+                "setitem required str to be resized beyond current memory allocation."
+                " Enter an unsafe context to allow this."
+            )
+
+        # Since the struct type might change, use a memmove
+        v = StrView(target, ref=False)
+        with self.unsafe(), v.unsafe():
+            v.move_to(self)
+        self._narrow_type()
+
+        # On modifications, unintern the string
+        self._pyobject.interned = 0
+
+    def insert(self, index: SupportsIndex, value: str) -> None:
+        """Insert object before index."""
+        index = index.__index__()
+        # Use a temp list for the slice calculation
+        temp = list(self._pyobject.into_object())
+        temp.insert(index, value)
+        # Combine to str
+        target = "".join(temp)
+
+        # See if resizing is safe
+        if target.__sizeof__() > self.mem_allocated and not self._unsafe:
+            raise UnsafeError(
+                "insert required str to be resized beyond current memory allocation."
+                " Enter an unsafe context to allow this."
+            )
+
+        # Since the struct type might change, use a memmove
+        v = StrView(target, ref=False)
+        with self.unsafe(), v.unsafe():
+            v.move_to(self)
+        self._narrow_type()
+
+        # On modifications, unintern the string
+        self._pyobject.interned = 0
 
     @property
     def length(self) -> int:
@@ -37,34 +160,20 @@ class StrView(View[str, None, None], Sequence):
 
     @property
     def interned(self) -> State:
-        return self._pyobject.interned
+        return State(self._pyobject.interned)
 
     @interned.setter
-    def interned(self, value: State) -> None:
+    def interned(self, value: State | int) -> None:
         self._pyobject.interned = value
 
     @property
-    def kind(self) -> int:
-        return self._pyobject.kind
+    def kind(self) -> Kind:
+        return Kind(self._pyobject.kind)
 
     @kind.setter
     def kind(self, value: Kind | int) -> None:
-        self._pyobject.kind = Kind(value)
+        self._pyobject.kind = value
 
     @property
     def buffer(self) -> Array[Py_ssize_t]:
         return self._pyobject.buffer
-
-    def __len__(self) -> int:
-        return str.__len__(self.base)
-
-    @overload
-    def __getitem__(self, index: int) -> _T:
-        ...
-
-    @overload
-    def __getitem__(self, index: slice) -> Sequence[_T]:
-        ...
-
-    def __getitem__(self, index: int | slice) -> _T:
-        return str.__getitem__(self.base, index)

--- a/src/einspect/views/view_str.py
+++ b/src/einspect/views/view_str.py
@@ -151,12 +151,12 @@ class StrView(View[str, None, None], MutableSequence):
 
     @property
     def hash(self) -> int:
-        return self._pyobject.hash  # type: ignore
+        return self._pyobject.hash
 
     @hash.setter
     @unsafe
     def hash(self, value: int) -> None:
-        self._pyobject.hash = value  # type: ignore
+        self._pyobject.hash = value
 
     @property
     def interned(self) -> State:

--- a/src/einspect/views/view_str.py
+++ b/src/einspect/views/view_str.py
@@ -32,13 +32,13 @@ class StrView(View[str, None, None], MutableSequence):
 
     def _narrow_type(self) -> None:
         # Narrow to a more specific unicode type if possible
-        if self._pyobject.ascii:
-            self._pyobject = self._pyobject.astype(PyASCIIObject)
-        else:
-            if self._pyobject.compact:
-                self._pyobject = self._pyobject.astype(PyCompactUnicodeObject)
+        if self._pyobject.compact:
+            if self._pyobject.ascii:
+                self._pyobject = self._pyobject.astype(PyASCIIObject)
             else:
-                self._pyobject = self._pyobject.astype(PyUnicodeObject)
+                self._pyobject = self._pyobject.astype(PyCompactUnicodeObject)
+        else:
+            self._pyobject = self._pyobject.astype(PyUnicodeObject)
 
     def __len__(self) -> int:
         return self._pyobject.GetLength()

--- a/src/einspect/views/view_str.py
+++ b/src/einspect/views/view_str.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import MutableSequence
 from ctypes import Array
-from typing import Iterable, SupportsIndex, TypeVar, overload
+from typing import Iterable, SupportsIndex, TypeVar, Union, overload
 
 from einspect.api import Py_ssize_t
 from einspect.errors import UnsafeError
@@ -22,7 +22,7 @@ _T = TypeVar("_T")
 
 
 class StrView(View[str, None, None], MutableSequence):
-    _pyobject: PyASCIIObject | PyCompactUnicodeObject | PyUnicodeObject
+    _pyobject: Union[PyASCIIObject, PyCompactUnicodeObject, PyUnicodeObject]
 
     def __init__(self, obj: str, ref: bool = REF_DEFAULT) -> None:
         """View a Python string object."""

--- a/tests/views/test_view_base.py
+++ b/tests/views/test_view_base.py
@@ -3,7 +3,7 @@ import gc
 import pytest
 
 from einspect import errors, structs, view
-from einspect.views.view_base import VarView, View
+from einspect.views.view_base import AnyView, VarView, View
 
 
 class TestView:
@@ -61,18 +61,6 @@ class TestView:
         v = self.view_type(obj, ref=True)
         assert v.base is obj
 
-    def test_base_weakref(self):
-        """Access base after weakref is deleted."""
-
-        class A:
-            pass
-
-        obj = A()
-        v = self.view_type(obj, ref=False)
-        del obj
-        with pytest.raises(errors.MovedError):
-            _ = v.base
-
     def test_base_no_ref(self):
         """Access base with no ref should require unsafe."""
         obj = self.get_obj()
@@ -117,3 +105,16 @@ class TestView:
         if not v.is_gc():
             assert not v.gc_is_tracked()
             assert not v.gc_may_be_tracked()
+
+
+def test_base_weakref():
+    """Access base after weakref is deleted."""
+
+    class A:
+        pass
+
+    obj = A()
+    v = AnyView(obj, ref=False)
+    del obj
+    with pytest.raises(errors.MovedError):
+        _ = v.base

--- a/tests/views/test_view_set.py
+++ b/tests/views/test_view_set.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import weakref
+from ctypes import addressof
+
+from einspect.structs import PyObject
 from einspect.views.view_set import SetView
 from tests.views.test_view_base import TestView
 
@@ -11,6 +15,73 @@ class TestSetView(TestView):
     def get_obj(self) -> set[int]:
         return {1, 2, 3}
 
+    def test_fields(self):
+        obj = {1, 2, 3}
+        v = self.view_type(obj)
+        assert v.fill == 3
+        assert v.used == 3
+        # Mask is 7, so table is 8 entries
+        assert v.mask == 7
+        assert len(v.table) == 8
+        # This should still use the smalltable
+        assert v.table[1].key.contents.into_object() == 1
+        assert v.smalltable[1].key.contents.into_object() == 1
+        assert addressof(v.table) == addressof(v.smalltable)
+
+    def test_mask(self):
+        # Mask should be table size - 1
+        # Smalltable starts at 8, so mask should be 7
+        obj = {"A", "B"}
+        v = self.view_type(obj)
+        assert v.mask == 7
+        # Set the mask
+        with v.unsafe():
+            v.mask = 7
+
+    def test_fill(self):
+        obj = {"A", "B"}
+        v = self.view_type(obj)
+        assert v.fill == 2
+        with v.unsafe():
+            v.fill = 2
+
+    def test_finger(self):
+        obj = {11, 22, 33}
+        v = self.view_type(obj)
+        assert v.finger == 0
+        assert obj.pop() == 33
+        assert v.finger == 2
+        assert obj.pop() == 11
+
+    def test_set_finger(self):
+        obj = {11, 22, 33}
+        v = self.view_type(obj)
+        with v.unsafe():
+            v.finger = 2
+        assert obj.pop() == 11
+        assert v.finger == 4
+        assert obj.pop() == 22
+
+    def test_table(self):
+        obj = {1, 2}
+        v = self.view_type(obj)
+
+        arr = v.table
+        # Set entry 3
+        arr[3].key = PyObject.from_object(3).as_ref()
+        arr[3].hash = hash(3)
+        with v.unsafe():
+            # Increase our size
+            v.used += 1
+            # Set the array
+            v.table = arr
+            # Small table should be set as well
+            assert v.smalltable[3].key.contents.into_object() == 3
+            # but we'll set it anyway
+            v.smalltable = arr
+        assert 3 in obj
+        assert obj == {1, 2, 3}
+
     def test_sized(self):
         obj = self.get_obj()
         orig_len = len(obj)
@@ -20,3 +91,14 @@ class TestSetView(TestView):
         assert len(v) == orig_len - 1
         obj.clear()
         assert len(v) == 0
+
+    def test_weakref(self):
+        obj = {"abc", "def"}
+        v = self.view_type(obj)
+
+        ref = v.weakreflist.contents.into_object()
+        assert isinstance(ref, weakref.ReferenceType)
+        assert ref() is obj
+
+        with v.unsafe():
+            v.weakreflist = PyObject.from_object(ref).as_ref()


### PR DESCRIPTION
Implement dynamic string struct subtypes to reflect CPython implementation:
- PyASCIIObject
- PyCompactUnicodeObject
- PyUnicodeObject

Added methods for StrView:
- `__delitem__` (index / slice)
- `__setitem__` (index / slice)
- append
- clear
- extend
- insert
- pop
- remove
- reverse

> These new methods will not require an unsafe context normally as they check the allocated memory bounds before any resize operation. If resizing will be beyond allocated memory, an `UnsafeError` is raised.

> An unsafe context can be entered to bypass this allocated memory check.