### PR TITLE
Add `PyObject.__new__` object overload with C-API allocators. Add NULL singleton.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
 project = "einspect"
 copyright = "2023, Ionite"
 author = "Ionite"
-release = "v0.5.0a1"
+release = "v0.5.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/poetry.lock
+++ b/poetry.lock
@@ -139,7 +139,7 @@ lxml = ["lxml"]
 
 [[package]]
 name = "bleach"
-version = "5.0.1"
+version = "6.0.0"
 description = "An easy safelist-based HTML-sanitizing tool."
 category = "dev"
 optional = false
@@ -151,7 +151,6 @@ webencodings = "*"
 
 [package.extras]
 css = ["tinycss2 (>=1.1.0,<1.2)"]
-dev = ["Sphinx (==4.3.2)", "black (==22.3.0)", "build (==0.8.0)", "flake8 (==4.0.1)", "hashin (==0.17.0)", "mypy (==0.961)", "pip-tools (==6.6.2)", "pytest (==7.1.2)", "tox (==3.25.0)", "twine (==4.0.1)", "wheel (==0.37.1)"]
 
 [[package]]
 name = "certifi"
@@ -223,7 +222,7 @@ test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
 
 [[package]]
 name = "coverage"
-version = "7.0.5"
+version = "7.1.0"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -237,7 +236,7 @@ toml = ["tomli"]
 
 [[package]]
 name = "debugpy"
-version = "1.6.5"
+version = "1.6.6"
 description = "An implementation of the Debug Adapter Protocol for Python"
 category = "dev"
 optional = false
@@ -388,7 +387,7 @@ sphinx-basic-ng = "*"
 
 [[package]]
 name = "identify"
-version = "2.5.13"
+version = "2.5.15"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -674,7 +673,7 @@ test = ["pexpect"]
 
 [[package]]
 name = "jupyter-core"
-version = "5.1.3"
+version = "5.1.5"
 description = "Jupyter core package. A base package on which Jupyter projects rely."
 category = "dev"
 optional = false
@@ -957,7 +956,7 @@ test = ["ipykernel", "ipython", "ipywidgets", "nbconvert (>=7.0.0)", "pytest (>=
 
 [[package]]
 name = "nbconvert"
-version = "7.2.8"
+version = "7.2.9"
 description = "Converting Jupyter Notebooks"
 category = "dev"
 optional = false
@@ -1168,7 +1167,7 @@ virtualenv = ">=20.10.0"
 
 [[package]]
 name = "prometheus-client"
-version = "0.15.0"
+version = "0.16.0"
 description = "Python client for the Prometheus monitoring system."
 category = "dev"
 optional = false
@@ -1600,8 +1599,8 @@ code_style = ["pre-commit (==2.12.1)"]
 rtd = ["ipython", "myst-nb", "sphinx", "sphinx-book-theme", "sphinx-examples"]
 
 [[package]]
-name = "sphinxcontrib.applehelp"
-version = "1.0.3"
+name = "sphinxcontrib-applehelp"
+version = "1.0.4"
 description = "sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books"
 category = "dev"
 optional = false
@@ -1922,8 +1921,8 @@ beautifulsoup4 = [
     {file = "beautifulsoup4-4.11.1.tar.gz", hash = "sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693"},
 ]
 bleach = [
-    {file = "bleach-5.0.1-py3-none-any.whl", hash = "sha256:085f7f33c15bd408dd9b17a4ad77c577db66d76203e5984b1bd59baeee948b2a"},
-    {file = "bleach-5.0.1.tar.gz", hash = "sha256:0d03255c47eb9bd2f26aa9bb7f2107732e7e8fe195ca2f64709fcf3b0a4a085c"},
+    {file = "bleach-6.0.0-py3-none-any.whl", hash = "sha256:33c16e3353dbd13028ab4799a0f89a83f113405c766e9c122df8a06f5b85b3f4"},
+    {file = "bleach-6.0.0.tar.gz", hash = "sha256:1a1a85c1595e07d8db14c5f09f09e6433502c51c595970edc090551f0db99414"},
 ]
 certifi = [
     {file = "certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"},
@@ -2102,77 +2101,77 @@ commonmark = [
     {file = "commonmark-0.9.1.tar.gz", hash = "sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60"},
 ]
 coverage = [
-    {file = "coverage-7.0.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2a7f23bbaeb2a87f90f607730b45564076d870f1fb07b9318d0c21f36871932b"},
-    {file = "coverage-7.0.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c18d47f314b950dbf24a41787ced1474e01ca816011925976d90a88b27c22b89"},
-    {file = "coverage-7.0.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef14d75d86f104f03dea66c13188487151760ef25dd6b2dbd541885185f05f40"},
-    {file = "coverage-7.0.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66e50680e888840c0995f2ad766e726ce71ca682e3c5f4eee82272c7671d38a2"},
-    {file = "coverage-7.0.5-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9fed35ca8c6e946e877893bbac022e8563b94404a605af1d1e6accc7eb73289"},
-    {file = "coverage-7.0.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d8d04e755934195bdc1db45ba9e040b8d20d046d04d6d77e71b3b34a8cc002d0"},
-    {file = "coverage-7.0.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:7e109f1c9a3ece676597831874126555997c48f62bddbcace6ed17be3e372de8"},
-    {file = "coverage-7.0.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0a1890fca2962c4f1ad16551d660b46ea77291fba2cc21c024cd527b9d9c8809"},
-    {file = "coverage-7.0.5-cp310-cp310-win32.whl", hash = "sha256:be9fcf32c010da0ba40bf4ee01889d6c737658f4ddff160bd7eb9cac8f094b21"},
-    {file = "coverage-7.0.5-cp310-cp310-win_amd64.whl", hash = "sha256:cbfcba14a3225b055a28b3199c3d81cd0ab37d2353ffd7f6fd64844cebab31ad"},
-    {file = "coverage-7.0.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:30b5fec1d34cc932c1bc04017b538ce16bf84e239378b8f75220478645d11fca"},
-    {file = "coverage-7.0.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1caed2367b32cc80a2b7f58a9f46658218a19c6cfe5bc234021966dc3daa01f0"},
-    {file = "coverage-7.0.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d254666d29540a72d17cc0175746cfb03d5123db33e67d1020e42dae611dc196"},
-    {file = "coverage-7.0.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:19245c249aa711d954623d94f23cc94c0fd65865661f20b7781210cb97c471c0"},
-    {file = "coverage-7.0.5-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b05ed4b35bf6ee790832f68932baf1f00caa32283d66cc4d455c9e9d115aafc"},
-    {file = "coverage-7.0.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:29de916ba1099ba2aab76aca101580006adfac5646de9b7c010a0f13867cba45"},
-    {file = "coverage-7.0.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:e057e74e53db78122a3979f908973e171909a58ac20df05c33998d52e6d35757"},
-    {file = "coverage-7.0.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:411d4ff9d041be08fdfc02adf62e89c735b9468f6d8f6427f8a14b6bb0a85095"},
-    {file = "coverage-7.0.5-cp311-cp311-win32.whl", hash = "sha256:52ab14b9e09ce052237dfe12d6892dd39b0401690856bcfe75d5baba4bfe2831"},
-    {file = "coverage-7.0.5-cp311-cp311-win_amd64.whl", hash = "sha256:1f66862d3a41674ebd8d1a7b6f5387fe5ce353f8719040a986551a545d7d83ea"},
-    {file = "coverage-7.0.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b69522b168a6b64edf0c33ba53eac491c0a8f5cc94fa4337f9c6f4c8f2f5296c"},
-    {file = "coverage-7.0.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:436e103950d05b7d7f55e39beeb4d5be298ca3e119e0589c0227e6d0b01ee8c7"},
-    {file = "coverage-7.0.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b8c56bec53d6e3154eaff6ea941226e7bd7cc0d99f9b3756c2520fc7a94e6d96"},
-    {file = "coverage-7.0.5-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a38362528a9115a4e276e65eeabf67dcfaf57698e17ae388599568a78dcb029"},
-    {file = "coverage-7.0.5-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:f67472c09a0c7486e27f3275f617c964d25e35727af952869dd496b9b5b7f6a3"},
-    {file = "coverage-7.0.5-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:220e3fa77d14c8a507b2d951e463b57a1f7810a6443a26f9b7591ef39047b1b2"},
-    {file = "coverage-7.0.5-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:ecb0f73954892f98611e183f50acdc9e21a4653f294dfbe079da73c6378a6f47"},
-    {file = "coverage-7.0.5-cp37-cp37m-win32.whl", hash = "sha256:d8f3e2e0a1d6777e58e834fd5a04657f66affa615dae61dd67c35d1568c38882"},
-    {file = "coverage-7.0.5-cp37-cp37m-win_amd64.whl", hash = "sha256:9e662e6fc4f513b79da5d10a23edd2b87685815b337b1a30cd11307a6679148d"},
-    {file = "coverage-7.0.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:790e4433962c9f454e213b21b0fd4b42310ade9c077e8edcb5113db0818450cb"},
-    {file = "coverage-7.0.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:49640bda9bda35b057b0e65b7c43ba706fa2335c9a9896652aebe0fa399e80e6"},
-    {file = "coverage-7.0.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d66187792bfe56f8c18ba986a0e4ae44856b1c645336bd2c776e3386da91e1dd"},
-    {file = "coverage-7.0.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:276f4cd0001cd83b00817c8db76730938b1ee40f4993b6a905f40a7278103b3a"},
-    {file = "coverage-7.0.5-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95304068686545aa368b35dfda1cdfbbdbe2f6fe43de4a2e9baa8ebd71be46e2"},
-    {file = "coverage-7.0.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:17e01dd8666c445025c29684d4aabf5a90dc6ef1ab25328aa52bedaa95b65ad7"},
-    {file = "coverage-7.0.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ea76dbcad0b7b0deb265d8c36e0801abcddf6cc1395940a24e3595288b405ca0"},
-    {file = "coverage-7.0.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:50a6adc2be8edd7ee67d1abc3cd20678987c7b9d79cd265de55941e3d0d56499"},
-    {file = "coverage-7.0.5-cp38-cp38-win32.whl", hash = "sha256:e4ce984133b888cc3a46867c8b4372c7dee9cee300335e2925e197bcd45b9e16"},
-    {file = "coverage-7.0.5-cp38-cp38-win_amd64.whl", hash = "sha256:4a950f83fd3f9bca23b77442f3a2b2ea4ac900944d8af9993743774c4fdc57af"},
-    {file = "coverage-7.0.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3c2155943896ac78b9b0fd910fb381186d0c345911f5333ee46ac44c8f0e43ab"},
-    {file = "coverage-7.0.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:54f7e9705e14b2c9f6abdeb127c390f679f6dbe64ba732788d3015f7f76ef637"},
-    {file = "coverage-7.0.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ee30375b409d9a7ea0f30c50645d436b6f5dfee254edffd27e45a980ad2c7f4"},
-    {file = "coverage-7.0.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b78729038abea6a5df0d2708dce21e82073463b2d79d10884d7d591e0f385ded"},
-    {file = "coverage-7.0.5-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13250b1f0bd023e0c9f11838bdeb60214dd5b6aaf8e8d2f110c7e232a1bff83b"},
-    {file = "coverage-7.0.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:2c407b1950b2d2ffa091f4e225ca19a66a9bd81222f27c56bd12658fc5ca1209"},
-    {file = "coverage-7.0.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:c76a3075e96b9c9ff00df8b5f7f560f5634dffd1658bafb79eb2682867e94f78"},
-    {file = "coverage-7.0.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:f26648e1b3b03b6022b48a9b910d0ae209e2d51f50441db5dce5b530fad6d9b1"},
-    {file = "coverage-7.0.5-cp39-cp39-win32.whl", hash = "sha256:ba3027deb7abf02859aca49c865ece538aee56dcb4871b4cced23ba4d5088904"},
-    {file = "coverage-7.0.5-cp39-cp39-win_amd64.whl", hash = "sha256:949844af60ee96a376aac1ded2a27e134b8c8d35cc006a52903fc06c24a3296f"},
-    {file = "coverage-7.0.5-pp37.pp38.pp39-none-any.whl", hash = "sha256:b9727ac4f5cf2cbf87880a63870b5b9730a8ae3a4a360241a0fdaa2f71240ff0"},
-    {file = "coverage-7.0.5.tar.gz", hash = "sha256:051afcbd6d2ac39298d62d340f94dbb6a1f31de06dfaf6fcef7b759dd3860c45"},
+    {file = "coverage-7.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3b946bbcd5a8231383450b195cfb58cb01cbe7f8949f5758566b881df4b33baf"},
+    {file = "coverage-7.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ec8e767f13be637d056f7e07e61d089e555f719b387a7070154ad80a0ff31801"},
+    {file = "coverage-7.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4a5a5879a939cb84959d86869132b00176197ca561c664fc21478c1eee60d75"},
+    {file = "coverage-7.1.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b643cb30821e7570c0aaf54feaf0bfb630b79059f85741843e9dc23f33aaca2c"},
+    {file = "coverage-7.1.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32df215215f3af2c1617a55dbdfb403b772d463d54d219985ac7cd3bf124cada"},
+    {file = "coverage-7.1.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:33d1ae9d4079e05ac4cc1ef9e20c648f5afabf1a92adfaf2ccf509c50b85717f"},
+    {file = "coverage-7.1.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:29571503c37f2ef2138a306d23e7270687c0efb9cab4bd8038d609b5c2393a3a"},
+    {file = "coverage-7.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:63ffd21aa133ff48c4dff7adcc46b7ec8b565491bfc371212122dd999812ea1c"},
+    {file = "coverage-7.1.0-cp310-cp310-win32.whl", hash = "sha256:4b14d5e09c656de5038a3f9bfe5228f53439282abcab87317c9f7f1acb280352"},
+    {file = "coverage-7.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:8361be1c2c073919500b6601220a6f2f98ea0b6d2fec5014c1d9cfa23dd07038"},
+    {file = "coverage-7.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:da9b41d4539eefd408c46725fb76ecba3a50a3367cafb7dea5f250d0653c1040"},
+    {file = "coverage-7.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c5b15ed7644ae4bee0ecf74fee95808dcc34ba6ace87e8dfbf5cb0dc20eab45a"},
+    {file = "coverage-7.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d12d076582507ea460ea2a89a8c85cb558f83406c8a41dd641d7be9a32e1274f"},
+    {file = "coverage-7.1.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e2617759031dae1bf183c16cef8fcfb3de7617f394c813fa5e8e46e9b82d4222"},
+    {file = "coverage-7.1.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c4e4881fa9e9667afcc742f0c244d9364d197490fbc91d12ac3b5de0bf2df146"},
+    {file = "coverage-7.1.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:9d58885215094ab4a86a6aef044e42994a2bd76a446dc59b352622655ba6621b"},
+    {file = "coverage-7.1.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:ffeeb38ee4a80a30a6877c5c4c359e5498eec095878f1581453202bfacc8fbc2"},
+    {file = "coverage-7.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3baf5f126f30781b5e93dbefcc8271cb2491647f8283f20ac54d12161dff080e"},
+    {file = "coverage-7.1.0-cp311-cp311-win32.whl", hash = "sha256:ded59300d6330be27bc6cf0b74b89ada58069ced87c48eaf9344e5e84b0072f7"},
+    {file = "coverage-7.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:6a43c7823cd7427b4ed763aa7fb63901ca8288591323b58c9cd6ec31ad910f3c"},
+    {file = "coverage-7.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7a726d742816cb3a8973c8c9a97539c734b3a309345236cd533c4883dda05b8d"},
+    {file = "coverage-7.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc7c85a150501286f8b56bd8ed3aa4093f4b88fb68c0843d21ff9656f0009d6a"},
+    {file = "coverage-7.1.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f5b4198d85a3755d27e64c52f8c95d6333119e49fd001ae5798dac872c95e0f8"},
+    {file = "coverage-7.1.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ddb726cb861c3117a553f940372a495fe1078249ff5f8a5478c0576c7be12050"},
+    {file = "coverage-7.1.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:51b236e764840a6df0661b67e50697aaa0e7d4124ca95e5058fa3d7cbc240b7c"},
+    {file = "coverage-7.1.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:7ee5c9bb51695f80878faaa5598040dd6c9e172ddcf490382e8aedb8ec3fec8d"},
+    {file = "coverage-7.1.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c31b75ae466c053a98bf26843563b3b3517b8f37da4d47b1c582fdc703112bc3"},
+    {file = "coverage-7.1.0-cp37-cp37m-win32.whl", hash = "sha256:3b155caf3760408d1cb903b21e6a97ad4e2bdad43cbc265e3ce0afb8e0057e73"},
+    {file = "coverage-7.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2a60d6513781e87047c3e630b33b4d1e89f39836dac6e069ffee28c4786715f5"},
+    {file = "coverage-7.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f2cba5c6db29ce991029b5e4ac51eb36774458f0a3b8d3137241b32d1bb91f06"},
+    {file = "coverage-7.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:beeb129cacea34490ffd4d6153af70509aa3cda20fdda2ea1a2be870dfec8d52"},
+    {file = "coverage-7.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c45948f613d5d18c9ec5eaa203ce06a653334cf1bd47c783a12d0dd4fd9c851"},
+    {file = "coverage-7.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ef382417db92ba23dfb5864a3fc9be27ea4894e86620d342a116b243ade5d35d"},
+    {file = "coverage-7.1.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c7c0d0827e853315c9bbd43c1162c006dd808dbbe297db7ae66cd17b07830f0"},
+    {file = "coverage-7.1.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:e5cdbb5cafcedea04924568d990e20ce7f1945a1dd54b560f879ee2d57226912"},
+    {file = "coverage-7.1.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:9817733f0d3ea91bea80de0f79ef971ae94f81ca52f9b66500c6a2fea8e4b4f8"},
+    {file = "coverage-7.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:218fe982371ac7387304153ecd51205f14e9d731b34fb0568181abaf7b443ba0"},
+    {file = "coverage-7.1.0-cp38-cp38-win32.whl", hash = "sha256:04481245ef966fbd24ae9b9e537ce899ae584d521dfbe78f89cad003c38ca2ab"},
+    {file = "coverage-7.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:8ae125d1134bf236acba8b83e74c603d1b30e207266121e76484562bc816344c"},
+    {file = "coverage-7.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2bf1d5f2084c3932b56b962a683074a3692bce7cabd3aa023c987a2a8e7612f6"},
+    {file = "coverage-7.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:98b85dd86514d889a2e3dd22ab3c18c9d0019e696478391d86708b805f4ea0fa"},
+    {file = "coverage-7.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38da2db80cc505a611938d8624801158e409928b136c8916cd2e203970dde4dc"},
+    {file = "coverage-7.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3164d31078fa9efe406e198aecd2a02d32a62fecbdef74f76dad6a46c7e48311"},
+    {file = "coverage-7.1.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db61a79c07331e88b9a9974815c075fbd812bc9dbc4dc44b366b5368a2936063"},
+    {file = "coverage-7.1.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9ccb092c9ede70b2517a57382a601619d20981f56f440eae7e4d7eaafd1d1d09"},
+    {file = "coverage-7.1.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:33ff26d0f6cc3ca8de13d14fde1ff8efe1456b53e3f0273e63cc8b3c84a063d8"},
+    {file = "coverage-7.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d47dd659a4ee952e90dc56c97d78132573dc5c7b09d61b416a9deef4ebe01a0c"},
+    {file = "coverage-7.1.0-cp39-cp39-win32.whl", hash = "sha256:d248cd4a92065a4d4543b8331660121b31c4148dd00a691bfb7a5cdc7483cfa4"},
+    {file = "coverage-7.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:7ed681b0f8e8bcbbffa58ba26fcf5dbc8f79e7997595bf071ed5430d8c08d6f3"},
+    {file = "coverage-7.1.0-pp37.pp38.pp39-none-any.whl", hash = "sha256:755e89e32376c850f826c425ece2c35a4fc266c081490eb0a841e7c1cb0d3bda"},
+    {file = "coverage-7.1.0.tar.gz", hash = "sha256:10188fe543560ec4874f974b5305cd1a8bdcfa885ee00ea3a03733464c4ca265"},
 ]
 debugpy = [
-    {file = "debugpy-1.6.5-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:696165f021a6a17da08163eaae84f3faf5d8be68fb78cd78488dd347e625279c"},
-    {file = "debugpy-1.6.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17039e392d6f38388a68bd02c5f823b32a92142a851e96ba3ec52aeb1ce9d900"},
-    {file = "debugpy-1.6.5-cp310-cp310-win32.whl", hash = "sha256:62a06eb78378292ba6c427d861246574dc8b84471904973797b29dd33c7c2495"},
-    {file = "debugpy-1.6.5-cp310-cp310-win_amd64.whl", hash = "sha256:9984fc00ab372c97f63786c400107f54224663ea293daab7b365a5b821d26309"},
-    {file = "debugpy-1.6.5-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:048368f121c08b00bbded161e8583817af5055982d2722450a69efe2051621c2"},
-    {file = "debugpy-1.6.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:74e4eca42055759032e3f1909d1374ba1d729143e0c2729bb8cb5e8b5807c458"},
-    {file = "debugpy-1.6.5-cp37-cp37m-win32.whl", hash = "sha256:0f9afcc8cad6424695f3356dc9a7406d5b18e37ee2e73f34792881a44b02cc50"},
-    {file = "debugpy-1.6.5-cp37-cp37m-win_amd64.whl", hash = "sha256:b5a74ecebe5253344501d9b23f74459c46428b30437fa9254cfb8cb129943242"},
-    {file = "debugpy-1.6.5-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:9e809ef787802c808995e5b6ade714a25fa187f892b41a412d418a15a9c4a432"},
-    {file = "debugpy-1.6.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:947c686e8adb46726f3d5f19854f6aebf66c2edb91225643c7f44b40b064a235"},
-    {file = "debugpy-1.6.5-cp38-cp38-win32.whl", hash = "sha256:377391341c4b86f403d93e467da8e2d05c22b683f08f9af3e16d980165b06b90"},
-    {file = "debugpy-1.6.5-cp38-cp38-win_amd64.whl", hash = "sha256:286ae0c2def18ee0dc8a61fa76d51039ca8c11485b6ed3ef83e3efe8a23926ae"},
-    {file = "debugpy-1.6.5-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:500dd4a9ff818f5c52dddb4a608c7de5371c2d7d905c505eb745556c579a9f11"},
-    {file = "debugpy-1.6.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f3fab217fe7e2acb2d90732af1a871947def4e2b6654945ba1ebd94bd0bea26"},
-    {file = "debugpy-1.6.5-cp39-cp39-win32.whl", hash = "sha256:15bc5febe0edc79726517b1f8d57d7ac7c784567b5ba804aab8b1c9d07a57018"},
-    {file = "debugpy-1.6.5-cp39-cp39-win_amd64.whl", hash = "sha256:7e84d9e4420122384cb2cc762a00b4e17cbf998022890f89b195ce178f78ff47"},
-    {file = "debugpy-1.6.5-py2.py3-none-any.whl", hash = "sha256:8116e40a1cd0593bd2aba01d4d560ee08f018da8e8fbd4cbd24ff09b5f0e41ef"},
-    {file = "debugpy-1.6.5.zip", hash = "sha256:5e55e6c79e215239dd0794ee0bf655412b934735a58e9d705e5c544f596f1603"},
+    {file = "debugpy-1.6.6-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:0ea1011e94416e90fb3598cc3ef5e08b0a4dd6ce6b9b33ccd436c1dffc8cd664"},
+    {file = "debugpy-1.6.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dff595686178b0e75580c24d316aa45a8f4d56e2418063865c114eef651a982e"},
+    {file = "debugpy-1.6.6-cp310-cp310-win32.whl", hash = "sha256:87755e173fcf2ec45f584bb9d61aa7686bb665d861b81faa366d59808bbd3494"},
+    {file = "debugpy-1.6.6-cp310-cp310-win_amd64.whl", hash = "sha256:72687b62a54d9d9e3fb85e7a37ea67f0e803aaa31be700e61d2f3742a5683917"},
+    {file = "debugpy-1.6.6-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:78739f77c58048ec006e2b3eb2e0cd5a06d5f48c915e2fc7911a337354508110"},
+    {file = "debugpy-1.6.6-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:23c29e40e39ad7d869d408ded414f6d46d82f8a93b5857ac3ac1e915893139ca"},
+    {file = "debugpy-1.6.6-cp37-cp37m-win32.whl", hash = "sha256:7aa7e103610e5867d19a7d069e02e72eb2b3045b124d051cfd1538f1d8832d1b"},
+    {file = "debugpy-1.6.6-cp37-cp37m-win_amd64.whl", hash = "sha256:f6383c29e796203a0bba74a250615ad262c4279d398e89d895a69d3069498305"},
+    {file = "debugpy-1.6.6-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:23363e6d2a04d726bbc1400bd4e9898d54419b36b2cdf7020e3e215e1dcd0f8e"},
+    {file = "debugpy-1.6.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b5d1b13d7c7bf5d7cf700e33c0b8ddb7baf030fcf502f76fc061ddd9405d16c"},
+    {file = "debugpy-1.6.6-cp38-cp38-win32.whl", hash = "sha256:70ab53918fd907a3ade01909b3ed783287ede362c80c75f41e79596d5ccacd32"},
+    {file = "debugpy-1.6.6-cp38-cp38-win_amd64.whl", hash = "sha256:c05349890804d846eca32ce0623ab66c06f8800db881af7a876dc073ac1c2225"},
+    {file = "debugpy-1.6.6-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:11a0f3a106f69901e4a9a5683ce943a7a5605696024134b522aa1bfda25b5fec"},
+    {file = "debugpy-1.6.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a771739902b1ae22a120dbbb6bd91b2cae6696c0e318b5007c5348519a4211c6"},
+    {file = "debugpy-1.6.6-cp39-cp39-win32.whl", hash = "sha256:549ae0cb2d34fc09d1675f9b01942499751d174381b6082279cf19cdb3c47cbe"},
+    {file = "debugpy-1.6.6-cp39-cp39-win_amd64.whl", hash = "sha256:de4a045fbf388e120bb6ec66501458d3134f4729faed26ff95de52a754abddb1"},
+    {file = "debugpy-1.6.6-py2.py3-none-any.whl", hash = "sha256:be596b44448aac14eb3614248c91586e2bc1728e020e82ef3197189aae556115"},
+    {file = "debugpy-1.6.6.zip", hash = "sha256:b9c2130e1c632540fbf9c2c88341493797ddf58016e7cba02e311de9b0a96b67"},
 ]
 decorator = [
     {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
@@ -2231,8 +2230,8 @@ furo = [
     {file = "furo-2022.12.7.tar.gz", hash = "sha256:d8008f8efbe7587a97ba533c8b2df1f9c21ee9b3e5cad0d27f61193d38b1a986"},
 ]
 identify = [
-    {file = "identify-2.5.13-py2.py3-none-any.whl", hash = "sha256:8aa48ce56e38c28b6faa9f261075dea0a942dfbb42b341b4e711896cbb40f3f7"},
-    {file = "identify-2.5.13.tar.gz", hash = "sha256:abb546bca6f470228785338a01b539de8a85bbf46491250ae03363956d8ebb10"},
+    {file = "identify-2.5.15-py2.py3-none-any.whl", hash = "sha256:1f4b36c5f50f3f950864b2a047308743f064eaa6f6645da5e5c780d1c7125487"},
+    {file = "identify-2.5.15.tar.gz", hash = "sha256:c22aa206f47cc40486ecf585d27ad5f40adbfc494a3fa41dc3ed0499a23b123f"},
 ]
 idna = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
@@ -2304,8 +2303,8 @@ jupyter-console = [
     {file = "jupyter_console-6.4.4.tar.gz", hash = "sha256:172f5335e31d600df61613a97b7f0352f2c8250bbd1092ef2d658f77249f89fb"},
 ]
 jupyter-core = [
-    {file = "jupyter_core-5.1.3-py3-none-any.whl", hash = "sha256:d23ab7db81ca1759f13780cd6b65f37f59bf8e0186ac422d5ca4982cc7d56716"},
-    {file = "jupyter_core-5.1.3.tar.gz", hash = "sha256:82e1cff0ef804c38677eff7070d5ff1d45037fef01a2d9ba9e6b7b8201831e9f"},
+    {file = "jupyter_core-5.1.5-py3-none-any.whl", hash = "sha256:83064d61bb2a9bc874e8184331c117b3778c2a7e1851f60cb00d273ceb3285ae"},
+    {file = "jupyter_core-5.1.5.tar.gz", hash = "sha256:8e54c48cde1e0c8345f64bcf9658b78044ddf02b273726cea9d9f59be4b02130"},
 ]
 jupyter-events = [
     {file = "jupyter_events-0.6.3-py3-none-any.whl", hash = "sha256:57a2749f87ba387cd1bfd9b22a0875b889237dbf2edc2121ebb22bde47036c17"},
@@ -2452,8 +2451,8 @@ nbclient = [
     {file = "nbclient-0.7.2.tar.gz", hash = "sha256:884a3f4a8c4fc24bb9302f263e0af47d97f0d01fe11ba714171b320c8ac09547"},
 ]
 nbconvert = [
-    {file = "nbconvert-7.2.8-py3-none-any.whl", hash = "sha256:ac57f2812175441a883f50c8ff113133ca65fe7ae5a9f1e3da3bfd1a70dce2ee"},
-    {file = "nbconvert-7.2.8.tar.gz", hash = "sha256:ccedacde57a972836bfb46466485be29ed1364ed7c2f379f62bad47d340ece99"},
+    {file = "nbconvert-7.2.9-py3-none-any.whl", hash = "sha256:495638c5e06005f4a5ce828d8a81d28e34f95c20f4384d5d7a22254b443836e7"},
+    {file = "nbconvert-7.2.9.tar.gz", hash = "sha256:a42c3ac137c64f70cbe4d763111bf358641ea53b37a01a5c202ed86374af5234"},
 ]
 nbformat = [
     {file = "nbformat-5.7.3-py3-none-any.whl", hash = "sha256:22a98a6516ca216002b0a34591af5bcb8072ca6c63910baffc901cfa07fefbf0"},
@@ -2512,8 +2511,8 @@ pre-commit = [
     {file = "pre_commit-2.21.0.tar.gz", hash = "sha256:31ef31af7e474a8d8995027fefdfcf509b5c913ff31f2015b4ec4beb26a6f658"},
 ]
 prometheus-client = [
-    {file = "prometheus_client-0.15.0-py3-none-any.whl", hash = "sha256:db7c05cbd13a0f79975592d112320f2605a325969b270a94b71dcabc47b931d2"},
-    {file = "prometheus_client-0.15.0.tar.gz", hash = "sha256:be26aa452490cfcf6da953f9436e95a9f2b4d578ca80094b4458930e5f584ab1"},
+    {file = "prometheus_client-0.16.0-py3-none-any.whl", hash = "sha256:0836af6eb2c8f4fed712b2f279f6c0a8bbab29f9f4aa15276b91c7cb0d1616ab"},
+    {file = "prometheus_client-0.16.0.tar.gz", hash = "sha256:a03e35b359f14dd1630898543e2120addfdeacd1a6069c1367ae90fd93ad3f48"},
 ]
 prompt-toolkit = [
     {file = "prompt_toolkit-3.0.36-py3-none-any.whl", hash = "sha256:aa64ad242a462c5ff0363a7b9cfe696c20d55d9fc60c11fd8e632d064804d305"},
@@ -2821,9 +2820,9 @@ sphinx-copybutton = [
     {file = "sphinx-copybutton-0.5.1.tar.gz", hash = "sha256:366251e28a6f6041514bfb5439425210418d6c750e98d3a695b73e56866a677a"},
     {file = "sphinx_copybutton-0.5.1-py3-none-any.whl", hash = "sha256:0842851b5955087a7ec7fc870b622cb168618ad408dee42692e9a5c97d071da8"},
 ]
-"sphinxcontrib.applehelp" = [
-    {file = "sphinxcontrib.applehelp-1.0.3-py3-none-any.whl", hash = "sha256:ba0f2a22e6eeada8da6428d0d520215ee8864253f32facf958cca81e426f661d"},
-    {file = "sphinxcontrib.applehelp-1.0.3.tar.gz", hash = "sha256:83749f09f6ac843b8cb685277dbc818a8bf2d76cc19602699094fe9a74db529e"},
+sphinxcontrib-applehelp = [
+    {file = "sphinxcontrib-applehelp-1.0.4.tar.gz", hash = "sha256:828f867945bbe39817c210a1abfd1bc4895c8b73fcaade56d45357a348a07d7e"},
+    {file = "sphinxcontrib_applehelp-1.0.4-py3-none-any.whl", hash = "sha256:29d341f67fb0f6f586b23ad80e072c8e6ad0b48417db2bde114a4c9746feb228"},
 ]
 sphinxcontrib-devhelp = [
     {file = "sphinxcontrib-devhelp-1.0.2.tar.gz", hash = "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ exclude_lines = [
     "pragma: no cover",
     "@overload",
     "@abstractmethod",
+    "if TYPE_CHECKING:",
     "log.debug",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "einspect"
-version = "0.5.0a1"
+version = "0.5.0"
 packages = [{ include = "einspect", from = "src" }]
 description = "Extended Inspect - view and modify memory structs of runtime objects."
 authors = ["ionite34 <dev@ionite.io>"]

--- a/src/einspect/__init__.py
+++ b/src/einspect/__init__.py
@@ -14,6 +14,6 @@ einspect._patch.run()
 
 __all__ = ("view", "unsafe", "impl", "orig", "ptr", "NULL")
 
-__version__ = "0.5.0a1"
+__version__ = "0.5.0"
 
 unsafe: ContextManager[None] = global_unsafe

--- a/src/einspect/__init__.py
+++ b/src/einspect/__init__.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 from typing import ContextManager
 
+# Runtime patches
+import einspect._patch
 from einspect.type_orig import orig
+from einspect.types import NULL, ptr
 from einspect.views.factory import view
 from einspect.views.unsafe import global_unsafe
 from einspect.views.view_type import impl
 
-__all__ = ("view", "unsafe", "impl", "orig")
+einspect._patch.run()
+
+__all__ = ("view", "unsafe", "impl", "orig", "ptr", "NULL")
 
 __version__ = "0.5.0a1"
 

--- a/src/einspect/_patch.py
+++ b/src/einspect/_patch.py
@@ -1,0 +1,39 @@
+"""Runtime patches."""
+from __future__ import annotations
+
+import ctypes
+from ctypes import POINTER, addressof, c_void_p, memmove, sizeof
+
+from einspect import types
+from einspect.structs.py_object import PyObject
+
+
+class _Null_LP_PyObject(POINTER(PyObject)):
+    _type_ = PyObject
+
+    def __repr__(self) -> str:
+        """Returns the string representation of the pointer."""
+        return f"<NULL ptr[PyObject] at {addressof(self):#04x}>"
+
+    def __eq__(self, other) -> bool:
+        """Returns equal to other null pointers."""
+        # noinspection PyUnresolvedReferences
+        if not isinstance(other, ctypes._Pointer):
+            return NotImplemented
+        return not other
+
+
+def run() -> None:
+    new_null = _Null_LP_PyObject()
+    PyObject.from_object(new_null).IncRef()
+
+    # Move the instance dict
+    types.NULL.__dict__ = new_null.__dict__
+
+    # Move the pointer object (excluding ob_refcnt)
+    ptr_size = sizeof(c_void_p)
+    memmove(
+        id(types.NULL) + ptr_size,
+        id(new_null) + ptr_size,
+        types.NULL.__sizeof__() - ptr_size,
+    )

--- a/src/einspect/api.py
+++ b/src/einspect/api.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 import ctypes
 from collections.abc import Sequence
-from ctypes import POINTER, Array, c_size_t, c_void_p, py_object, pythonapi, sizeof
-from typing import Any, Callable, TypeVar, Union
+from ctypes import Array, c_size_t, c_void_p, pythonapi, sizeof
+from typing import Any, Callable, TypeVar
 
 import _ctypes
 from typing_extensions import Annotated
@@ -37,10 +37,6 @@ uintptr_t = ctypes.c_uint64
 
 PTR_SIZE = sizeof(c_void_p)
 """Size of a pointer in bytes."""
-
-ObjectOrRef = Union[py_object, object]
-IntSize = Union[int, Py_ssize_t]
-PyObjectPtr = POINTER(py_object)
 
 # Alignments (must be powers of 2)
 # https://github.com/python/cpython/blob/3.11/Objects/obmalloc.c#L878-L884
@@ -186,7 +182,7 @@ class Py:
             """
 
 
-PyObj_FromPtr: Callable[[IntSize], object] = _ctypes.PyObj_FromPtr
+PyObj_FromPtr: Callable[[int], object] = _ctypes.PyObj_FromPtr
 """(Py_ssize_t ptr) -> Py_ssize_t"""
 
 

--- a/src/einspect/api.py
+++ b/src/einspect/api.py
@@ -83,47 +83,45 @@ class Py:
         """
 
     class Tuple:
-        Size: Callable[[ObjectOrRef], int] = pythonapi["PyTuple_Size"]
-        """
-        Return the size of a tuple object.
-        https://docs.python.org/3/c-api/tuple.html#c.PyTuple_Size
-        """
-        Size.argtypes = (py_object,)  # type: ignore
-        Size.restype = Py_ssize_t  # type: ignore
+        @bind_api(pythonapi["PyTuple_Size"])
+        @staticmethod
+        def Size(obj: tuple) -> int:
+            """
+            Return the size of a tuple object.
+            https://docs.python.org/3/c-api/tuple.html#c.PyTuple_Size
+            """
 
-        GetItem: Callable[[ObjectOrRef, IntSize], object] = pythonapi["PyTuple_GetItem"]
-        """
-        Return the item at position index in the tuple o.
-        https://docs.python.org/3/c-api/tuple.html#c.PyTuple_GetItem
-        """
-        GetItem.argtypes = (py_object, Py_ssize_t)  # type: ignore
-        GetItem.restype = py_object  # type: ignore
+        @bind_api(pythonapi["PyTuple_GetItem"])
+        @staticmethod
+        def GetItem(obj: tuple, index: int) -> object:
+            """
+            Return the item at position index in the tuple o.
+            https://docs.python.org/3/c-api/tuple.html#c.PyTuple_GetItem
+            """
 
-        SetItem: Callable[[ObjectOrRef, IntSize, ObjectOrRef], None] = pythonapi[
-            "PyTuple_SetItem"
-        ]
-        """
-        Set the item at position index in the tuple o to v.
-        https://docs.python.org/3/c-api/tuple.html#c.PyTuple_SetItem
+        @bind_api(pythonapi["PyTuple_SetItem"])
+        @staticmethod
+        def SetItem(obj: tuple, index: int, value: object) -> None:
+            """
+            Set the item at position index in the tuple o to v.
+            https://docs.python.org/3/c-api/tuple.html#c.PyTuple_SetItem
 
-        Notes:
-            - This function steals a reference to v.
-            - Requires tuple o to have a reference count == 1.
-        """
-        SetItem.argtypes = (py_object, Py_ssize_t, py_object)  # type: ignore
-        SetItem.restype = None  # type: ignore
+            Notes:
+                - This function steals a reference to v.
+                - Requires tuple o to have a reference count == 1.
+            """
 
-        Resize: Callable[[PyObjectPtr, IntSize], None] = pythonapi["_PyTuple_Resize"]
-        """
-        Resize the tuple to the specified size.
-        https://docs.python.org/3/c-api/tuple.html#c._PyTuple_Resize
+        @bind_api(pythonapi["_PyTuple_Resize"])
+        @staticmethod
+        def Resize(obj: tuple, size: int) -> None:
+            """
+            Resize the tuple to the specified size.
+            https://docs.python.org/3/c-api/tuple.html#c._PyTuple_Resize
 
-        Notes:
-            - Not part of the documented limited C API.
-            - Requires tuple o to have ref-count = 1 or size = 0
-        """
-        Resize.argtypes = (POINTER(py_object), Py_ssize_t)  # type: ignore
-        Resize.restype = None  # type: ignore
+            Notes:
+                - Not part of the documented limited C API.
+                - Requires tuple o to have ref-count = 1 or size = 0.
+            """
 
     class Type:
         @bind_api(pythonapi["PyType_Modified"])

--- a/src/einspect/errors.py
+++ b/src/einspect/errors.py
@@ -9,22 +9,6 @@ class UnsafeError(RuntimeError):
     """Unsafe operation without unsafe context."""
 
 
-class UnsafeAttributeError(UnsafeError, AttributeError):
-    """Unsafe attribute access."""
-
-    @classmethod
-    def from_attr(cls, attr: str) -> UnsafeError:
-        """Create an UnsafeError from an attribute name."""
-        return cls(
-            f"Setting attribute {attr!r} requires "
-            f"entering the unsafe() context manager"
-        )
-
-
-class UnsafeIndexError(UnsafeError, IndexError):
-    """Unsafe index access."""
-
-
 class DroppedReferenceError(RuntimeError):
     """Raised on access to a dropped object's reference."""
 

--- a/src/einspect/structs/mapping_proxy.py
+++ b/src/einspect/structs/mapping_proxy.py
@@ -6,6 +6,7 @@ from typing import TypeVar
 from einspect.structs.deco import struct
 from einspect.structs.py_dict import PyDictObject
 from einspect.structs.py_object import Fields, PyObject
+from einspect.structs.traits import IsGC
 from einspect.types import ptr
 
 __all__ = ("MappingProxyObject",)
@@ -16,7 +17,7 @@ _VT_co = TypeVar("_VT_co", covariant=True)
 
 
 @struct
-class MappingProxyObject(PyObject[MappingProxyType, _KT, _VT_co]):
+class MappingProxyObject(PyObject[MappingProxyType, _KT, _VT_co], IsGC):
     """
     Defines a mappingproxyobject Structure.
 

--- a/src/einspect/structs/py_dict.py
+++ b/src/einspect/structs/py_dict.py
@@ -22,7 +22,7 @@ from typing_extensions import Annotated
 from einspect.protocols.delayed_bind import bind_api
 from einspect.structs.deco import struct
 from einspect.structs.py_object import Fields, PyObject
-from einspect.structs.traits import Display
+from einspect.structs.traits import Display, IsGC
 from einspect.types import Array, ptr
 
 __all__ = ("PyDictObject",)
@@ -100,7 +100,7 @@ class PyDictValues(Structure, Display):
 
 
 @struct
-class PyDictObject(PyObject[dict, _KT, _VT]):
+class PyDictObject(PyObject[dict, _KT, _VT], IsGC):
     """
     Defines a PyDictObject Structure.
 

--- a/src/einspect/structs/py_list.py
+++ b/src/einspect/structs/py_list.py
@@ -8,6 +8,7 @@ from typing_extensions import Annotated
 from einspect.protocols.delayed_bind import bind_api
 from einspect.structs.deco import struct
 from einspect.structs.py_object import Fields, PyObject, PyVarObject
+from einspect.structs.traits import IsGC
 from einspect.types import ptr
 
 _VT = TypeVar("_VT")
@@ -15,7 +16,7 @@ _VT = TypeVar("_VT")
 
 # noinspection PyPep8Naming
 @struct
-class PyListObject(PyVarObject[list, None, _VT]):
+class PyListObject(PyVarObject[list, None, _VT], IsGC):
     """
     Defines a PyListObject Structure.
 

--- a/src/einspect/structs/py_object.py
+++ b/src/einspect/structs/py_object.py
@@ -82,9 +82,8 @@ class PyObject(Structure, AsRef, Generic[_T, _KT, _VT]):
             # Use from_object
             return cls.from_object(__obj)
         # Check kwargs
-        req = ["ob_type"]
-        if any(field := item not in kwargs for item in req):
-            raise TypeError(f"Missing required keyword-argument field of {field!r}")
+        if "ob_type" not in kwargs:
+            raise TypeError("Missing required keyword-argument field 'ob_type'")
 
         ob_size: int = kwargs.get("ob_size", 0).__index__()
         ob_type = PyTypeObject.try_from(kwargs["ob_type"])

--- a/src/einspect/structs/py_set.py
+++ b/src/einspect/structs/py_set.py
@@ -8,7 +8,7 @@ from typing_extensions import Annotated
 from einspect.api import Py_hash_t
 from einspect.structs.deco import struct
 from einspect.structs.py_object import PyObject
-from einspect.structs.traits import AsRef
+from einspect.structs.traits import AsRef, IsGC
 from einspect.types import ptr
 
 _T = TypeVar("_T")
@@ -24,7 +24,7 @@ class SetEntry(Structure, AsRef, Generic[_T]):
 
 
 @struct
-class PySetObject(PyObject[set, None, _T], AsRef):
+class PySetObject(PyObject[set, None, _T], AsRef, IsGC):
     """
     Defines a PySetObject Structure.
 

--- a/src/einspect/structs/py_tuple.py
+++ b/src/einspect/structs/py_tuple.py
@@ -9,13 +9,14 @@ from einspect.api import Py_ssize_t, seq_to_array
 from einspect.protocols.delayed_bind import bind_api
 from einspect.structs.deco import struct
 from einspect.structs.py_object import Fields, PyObject, PyVarObject
+from einspect.structs.traits import IsGC
 from einspect.types import Array, ptr
 
 _VT = TypeVar("_VT")
 
 
 @struct
-class PyTupleObject(PyVarObject[tuple, None, _VT]):
+class PyTupleObject(PyVarObject[tuple, None, _VT], IsGC):
     """
     Defines a PyTupleObject Structure.
 

--- a/src/einspect/structs/py_unicode.py
+++ b/src/einspect/structs/py_unicode.py
@@ -25,6 +25,7 @@ from einspect.api import Py_hash_t
 from einspect.protocols import bind_api
 from einspect.structs.deco import struct
 from einspect.structs.py_object import Fields, PyObject
+from einspect.structs.traits import IsGC
 from einspect.types import Array, char_p, ptr, void_p, wchar_p
 
 
@@ -125,7 +126,7 @@ class LegacyUnion(Union):
 
 
 @struct
-class PyASCIIObject(PyObject[str, None, None]):
+class PyASCIIObject(PyObject[str, None, None], IsGC):
     """
     Defines a PyUnicodeObject Structure
     """

--- a/src/einspect/structs/traits.py
+++ b/src/einspect/structs/traits.py
@@ -23,3 +23,9 @@ class Display:
         The address shown is the address of the Structure, not the object.
         """
         return f"<{self.__class__.__name__} at {addressof(self):#04x}>"
+
+
+class IsGC:
+    """Mixin for Structures that have a GC_Head."""
+
+    _is_gc_ = True

--- a/src/einspect/types.py
+++ b/src/einspect/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ctypes
 import typing
 
@@ -7,9 +9,12 @@ from typing import TYPE_CHECKING, List, TypeVar, get_origin, overload
 
 from typing_extensions import Self
 
-__all__ = ("ptr", "Array", "_SelfPtr")
-
 from einspect.compat import Version
+
+if TYPE_CHECKING:
+    from einspect.structs import PyObject
+
+__all__ = ("ptr", "Array", "NULL", "_SelfPtr")
 
 _T = TypeVar("_T")
 
@@ -20,8 +25,23 @@ Dynamic typing alias for ctypes.pointer.
 Resolves to the `_Ptr` class at runtime to allow for generic subscripting.
 """
 
+# noinspection PyUnresolvedReferences, PyProtectedMember
+Pointer = ctypes._Pointer
+"""Alias to `ctypes._Pointer`."""
+
 _SelfPtr = object()
 """Singleton object returned on ptr[Self]."""
+
+_Null_Type = type(
+    "NullType",
+    (ctypes.POINTER(ctypes.c_void_p),),
+    {
+        "_type_": ctypes.c_void_p,
+    },
+)
+
+NULL: ptr[PyObject] = _Null_Type()
+"""Singleton NULL pointer of type ptr[PyObject]."""
 
 
 class _Ptr(_Pointer):

--- a/src/einspect/views/view_base.py
+++ b/src/einspect/views/view_base.py
@@ -20,12 +20,7 @@ from typing import (
 )
 
 from einspect.api import PTR_SIZE, Py, PyObj_FromPtr, align_size
-from einspect.errors import (
-    DroppedReference,
-    MovedError,
-    UnsafeAttributeError,
-    UnsafeError,
-)
+from einspect.errors import DroppedReference, MovedError, UnsafeError
 from einspect.structs import PyObject, PyTypeObject, PyVarObject
 from einspect.views._display import Formatter
 from einspect.views.moves import _check_move
@@ -127,9 +122,8 @@ class View(BaseView[_T, _KT, _VT]):
         return int(self._pyobject.ob_refcnt)  # type: ignore
 
     @ref_count.setter
+    @unsafe
     def ref_count(self, value: int) -> None:
-        if not self._unsafe:
-            raise UnsafeAttributeError.from_attr("ref_count")
         self._pyobject.ob_refcnt = value
 
     @property

--- a/src/einspect/views/view_str.py
+++ b/src/einspect/views/view_str.py
@@ -29,9 +29,10 @@ def _check_resize(v: StrView, target: int, method: str) -> None:
         UnsafeError: If the string cannot be resized, and not in an unsafe context.
     """
     # See if resizing is safe
-    if target.__sizeof__() > v.mem_allocated and not v._unsafe:
+    if target > v.mem_allocated and not v._unsafe:
         raise UnsafeError(
-            f"{method} required str to be resized beyond current memory allocation."
+            f"string {method} required {target} bytes, beyond current"
+            f" allocated memory of {v.mem_allocated} bytes."
             " Enter an unsafe context to allow this."
         )
 
@@ -57,7 +58,7 @@ class StrView(View[str, None, None], MutableSequence):
         self._narrow_type()
 
     def _narrow_type(self) -> None:
-        # Narrow to a more specific unicode type if possible
+        """Narrow to a more specific unicode type if possible."""
         if self._pyobject.compact:
             if self._pyobject.ascii:
                 self._pyobject = self._pyobject.astype(PyASCIIObject)

--- a/tests/structs/test_gc.py
+++ b/tests/structs/test_gc.py
@@ -1,0 +1,21 @@
+import pytest
+
+from einspect.structs import PyObject
+
+
+def test_from_gc() -> None:
+    ls = [1, 2, 3]
+    obj = PyObject.from_object(ls)
+    assert obj.is_gc()
+    gc_head = obj.as_gc()
+    assert PyObject.from_gc(gc_head).into_object() is ls
+
+
+@pytest.mark.run_in_subprocess
+def test_gc_head_api():
+    obj = ["test", "123"]
+    py_obj = PyObject.from_object(obj)
+    gc_head = py_obj.as_gc()
+
+    assert gc_head.Set_Prev(gc_head.Prev()) is None
+    assert gc_head.Set_Next(gc_head.Next()) is None

--- a/tests/structs/test_structs.py
+++ b/tests/structs/test_structs.py
@@ -244,6 +244,26 @@ def test_try_from(src, py_obj):
     assert res.into_object() == py_obj
 
 
+def test_new_obj():
+    """Test PyObject.__new__ with __obj argument."""
+    s = "hello"
+    py_obj = st.PyObject.from_object(s)
+    py_new = st.PyObject(s)
+    assert py_obj.into_object() is s
+    assert py_new.into_object() is s
+
+
+def test_new_fields():
+    """Test PyObject.__new__ with fields kwargs."""
+    obj = st.PyTupleObject(
+        ob_refcnt=1,
+        ob_type=st.PyTypeObject(tuple).as_ref(),
+        ob_size=2,
+        ob_item=["hello", "hi"],
+    )
+    assert obj.into_object() == ("hello", "hi")
+
+
 def test_try_from_err_ctype():
     with pytest.raises(TypeError):
         st.PyObject.try_from(ctypes.c_void_p(0))

--- a/tests/structs/test_structs.py
+++ b/tests/structs/test_structs.py
@@ -231,11 +231,19 @@ def test_mem_size_basic(obj, struct, delta):
     assert py_object.mem_size == type(obj).__basicsize__
 
 
-@pytest.mark.run_in_subprocess
-def test_gc_head_api():
-    obj = ["test", "123"]
-    py_obj = st.PyObject.from_object(obj)
-    gc_head = py_obj.as_gc()
+@pytest.mark.parametrize(
+    ["src", "py_obj"],
+    [
+        (123, 123),
+        (st.PyObject.from_object(123), 123),
+        (st.PyObject.from_object(123).as_ref(), 123),
+    ],
+)
+def test_try_from(src, py_obj):
+    res = st.PyObject.try_from(src)
+    assert res.into_object() == py_obj
 
-    assert gc_head.Set_Prev(gc_head.Prev()) is None
-    assert gc_head.Set_Next(gc_head.Next()) is None
+
+def test_try_from_err_ctype():
+    with pytest.raises(TypeError):
+        st.PyObject.try_from(ctypes.c_void_p(0))

--- a/tests/structs/test_structs.py
+++ b/tests/structs/test_structs.py
@@ -186,10 +186,14 @@ class TestPyLongObject:
 
 class TestPyTupleObject:
     def test_item(self):
-        tup = literal_eval("(1, 2, 3)")
+        tup = literal_eval("(1,)")
         obj = st.PyTupleObject.from_object(tup)
         obj.ob_item = [st.PyObject.from_object(17).as_ref()]
-        assert obj.into_object() == (17, 2, 3)
+        assert obj.into_object() == (17,)
+        # Use array as well
+        arr_type = type(obj.ob_item)
+        obj.ob_item = arr_type(st.PyObject.from_object(5).as_ref())
+        assert obj.into_object() == (5,)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -1,0 +1,16 @@
+from ctypes import POINTER, c_void_p
+
+from einspect._patch import _Null_LP_PyObject
+
+
+def test_null_lp_repr() -> None:
+    obj = _Null_LP_PyObject()
+    assert repr(obj).startswith("<NULL ptr[PyObject] at")
+
+
+def test_null_lp_eq() -> None:
+    obj = _Null_LP_PyObject()
+    other_null_ptr = POINTER(c_void_p)()
+    assert obj is not other_null_ptr
+    assert obj == other_null_ptr
+    assert obj != "other"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,8 +1,10 @@
 import ctypes
+from ctypes import POINTER, c_uint32, c_void_p
 
 import pytest
 
-from einspect.types import ptr
+from einspect.structs import PyObject
+from einspect.types import NULL, ptr
 
 
 def test_ptr() -> None:
@@ -12,3 +14,31 @@ def test_ptr() -> None:
     # TypeError if wrong type
     with pytest.raises(TypeError):
         _ = ptr[123]
+
+
+@pytest.mark.parametrize(
+    "ptr_obj",
+    [
+        POINTER(PyObject)(),
+        POINTER(c_void_p)(),
+        POINTER(c_uint32)(),
+    ],
+)
+def test_null_eq(ptr_obj) -> None:
+    """Test NULL singleton."""
+    # Should be equal to other NULL pointers
+    assert NULL is not ptr_obj
+    assert NULL == ptr_obj
+
+
+@pytest.mark.parametrize(
+    "ptr_obj",
+    [
+        POINTER(c_void_p)(c_void_p(123)),
+        PyObject.from_object(123).as_ref(),
+    ],
+)
+def test_null_not_eq(ptr_obj) -> None:
+    """Test NULL singleton."""
+    # Should not be equal to other non-NULL pointers
+    assert NULL != ptr_obj

--- a/tests/test_unsafe.py
+++ b/tests/test_unsafe.py
@@ -1,6 +1,4 @@
 """Test unsafe context and operations."""
-from ctypes import POINTER, c_int, pointer
-
 import pytest
 
 from einspect import errors, unsafe, view

--- a/tests/test_unsafe.py
+++ b/tests/test_unsafe.py
@@ -3,13 +3,24 @@ from ctypes import POINTER, c_int, pointer
 
 import pytest
 
-from einspect import errors, view
+from einspect import errors, unsafe, view
 
 
-def test_unsafe_error():
+def test_unsafe_error() -> None:
     v = view(1)
     with pytest.raises(errors.UnsafeError):
-        v.ref_count = 0
+        v.ref_count += 1
+
+
+def test_global_unsafe() -> None:
+    v = view(1)
+    assert not v._unsafe
+    assert not v._local_unsafe
+    with unsafe():
+        assert v._unsafe
+        assert not v._local_unsafe
+    assert not v._unsafe
+    assert not v._local_unsafe
 
 
 @pytest.mark.run_in_subprocess

--- a/tests/views/test_move.py
+++ b/tests/views/test_move.py
@@ -19,6 +19,19 @@ def test_move_from(new_int: int):
     assert id(new_int) != id(5)
 
 
+def test_move_instance_dicts():
+    """Move between objects with instance dicts."""
+    Foo = type("Num", (tuple,), {})
+    Bar = type("Num", (tuple,), {})
+
+    x = Foo((1, 2, 3))
+    y = Bar((4, 5, 6))
+
+    view(x) << view(y)
+    assert x == (4, 5, 6)
+    assert x.__dict__ is y.__dict__
+
+
 def test_move_unsafe_size():
     """Unsafe move due to size."""
     v = view(5)

--- a/tests/views/test_move.py
+++ b/tests/views/test_move.py
@@ -1,4 +1,6 @@
 """Test moving of views."""
+from ast import literal_eval
+
 import pytest
 
 from einspect import view
@@ -30,6 +32,17 @@ def test_move_instance_dicts():
     view(x) << view(y)
     assert x == (4, 5, 6)
     assert x.__dict__ is y.__dict__
+
+
+def test_move_str():
+    """Move between strs."""
+    a = literal_eval("'abcdef'")
+    b = literal_eval("'xyz'")
+    assert a == "abcdef"
+    assert hash(a) == hash("abcdef")
+    view(a) << view(b)
+    assert a == "xyz"
+    assert hash(a) == hash("xyz")
 
 
 def test_move_unsafe_size():

--- a/tests/views/test_view_str.py
+++ b/tests/views/test_view_str.py
@@ -1,9 +1,12 @@
+from ast import literal_eval
+from contextlib import ExitStack
 from uuid import uuid4
 
 import pytest
 
 from einspect import view
-from einspect.structs.py_unicode import Kind, State
+from einspect.errors import UnsafeError
+from einspect.structs.py_unicode import Kind, PyCompactUnicodeObject, State
 from einspect.views.view_str import StrView
 from tests.views.test_view_base import TestView
 
@@ -13,17 +16,29 @@ class TestStrView(TestView):
     obj_type = str
 
     def get_obj(self) -> str:
-        return "2fe7b604-9664-41e6-9af0-9b472864bfc8"
+        return literal_eval("'2fe7b604-9664-41e6-9af0-9b472864bfc8'")
 
-    def test_properties(self):
+    def test_unicode(self) -> None:
+        text = literal_eval("'🤔'")
+        v = view(text)
+        assert v.buffer[0] == ord("🤔")
+        assert isinstance(v._pyobject, PyCompactUnicodeObject)
+
+    def test_properties(self) -> None:
         text = self.get_obj()
-        str_view = view(text)
-        assert str_view.length == len(text)
+        v = view(text)
+        assert v.length == len(text)
         expected_hash = hash(text)
-        assert str_view.hash == expected_hash
-        assert str_view.kind == Kind.PyUnicode_1BYTE
+        assert v.hash == expected_hash
+        assert v.kind == Kind.PyUnicode_1BYTE
 
-    def test_intern(self):
+    def test_unsafe_resize(self) -> None:
+        text = "abc"
+        v = view(text)
+        with pytest.raises(UnsafeError):
+            v.append("x" * 64)
+
+    def test_intern(self) -> None:
         text = self.get_obj()
         str_view = view(text)
         # Module level literal should be not interned
@@ -32,16 +47,45 @@ class TestStrView(TestView):
         s = "hi"
         assert view(s).interned == State.INTERNED_MORTAL
 
-    def test_buffer(self):
+    def test_setters(self) -> None:
+        text = self.get_obj()
+        v = self.view_type(text)
+
+        with ExitStack() as stack, v.unsafe():
+            # Check -1 hash will reset the hash cache
+            v.hash = -1
+            assert v.hash == -1
+            hash(text)
+            assert v.hash == hash(text)
+            assert v.hash != -1
+
+            orig_len = len(text)
+            assert v.length == orig_len
+            stack.callback(lambda: setattr(v, "length", orig_len))
+            v.length = orig_len // 2
+            assert len(text) == orig_len // 2
+
+            assert v.interned == State.NOT_INTERNED
+            stack.callback(lambda: setattr(v, "interned", State.NOT_INTERNED))
+            v.interned = State.INTERNED_MORTAL
+            assert v.interned == State.INTERNED_MORTAL
+
+            assert v.kind == Kind.PyUnicode_1BYTE
+            stack.callback(lambda: setattr(v, "kind", Kind.PyUnicode_1BYTE))
+            v.kind = Kind.PyUnicode_2BYTE
+            assert v.kind == Kind.PyUnicode_2BYTE
+
+    def test_buffer(self) -> None:
         text = self.get_obj()
         str_view = view(text)
         assert str_view.buffer[:] == text.encode("ascii")
 
 
-def test_str_setitem():
+def test_str_setitem() -> None:
     s = uuid4().hex
     orig_len = len(s)
     v = StrView(s)
+    assert v.interned == State.NOT_INTERNED
     v[0] = "1"
     v[-1] = "Z"
     assert s[0] == "1"
@@ -55,7 +99,7 @@ def test_str_setitem():
     assert len(s) == orig_len - 1
 
 
-def test_str_mutable_sequence():
+def test_str_mutable_sequence() -> None:
     s = uuid4().hex
     orig_len = len(s)
     last = s[-1]
@@ -64,3 +108,15 @@ def test_str_mutable_sequence():
     v.append("@")
     assert s[-1] == "@"
     assert len(s) == orig_len
+
+
+def test_str_remove() -> None:
+    s = literal_eval("'4ff4-e1219224-5462'")
+    assert s is not "4ff4-e1219224-5462"
+    v = StrView(s)
+    assert v.interned == State.NOT_INTERNED
+    v.remove("1219224")
+    assert s == "4ff4-e-5462"
+    # Removes only first instance
+    v.remove("-")
+    assert s == "4ff4e-5462"


### PR DESCRIPTION
- Add IsGC trait to PyObjects that have a GC_Head
- Add new `PyObject.__new__` overloads, accepts 1 positional argument to invoke `from_object` behavior, otherwise kwargs to set fields. Uses C-APIs to initialize structs.
- Add a new singleton type `einspect.NULL`, which is a null PyObject pointer, but also compares equal to other null pointers. When used in an array assignment, functions like `seq_to_array` will cast this singleton to the appropriate null type of the array.