### PR TITLE
Added PyCFunctionObject and CFunctionView

### DIFF
--- a/docs/source/api/structs/index.md
+++ b/docs/source/api/structs/index.md
@@ -14,6 +14,8 @@ mapping_proxy
 py_set
 py_unicode
 py_tuple
+py_function
+py_cfunction
 py_type
 traits
 ```

--- a/docs/source/api/structs/py_cfunction.rst
+++ b/docs/source/api/structs/py_cfunction.rst
@@ -1,0 +1,6 @@
+PyCFunctionObject
+=================
+
+.. autoclass:: einspect.structs.py_cfunction.PyCFunctionObject
+   :members:
+   :inherited-members:

--- a/docs/source/api/structs/py_function.rst
+++ b/docs/source/api/structs/py_function.rst
@@ -1,0 +1,6 @@
+PyFunctionObject
+================
+
+.. autoclass:: einspect.structs.py_function.PyFunctionObject
+   :members:
+   :inherited-members:

--- a/docs/source/api/views/index.md
+++ b/docs/source/api/views/index.md
@@ -13,5 +13,7 @@ view_mapping_proxy
 view_set
 view_str
 view_tuple
+view_function
+view_cfunction
 view_type
 ```

--- a/docs/source/api/views/view_cfunction.rst
+++ b/docs/source/api/views/view_cfunction.rst
@@ -1,0 +1,6 @@
+CFunctionView
+=============
+
+.. autoclass:: einspect.views.view_cfunction.CFunctionView
+   :members:
+   :inherited-members:

--- a/docs/source/api/views/view_function.rst
+++ b/docs/source/api/views/view_function.rst
@@ -1,0 +1,6 @@
+FunctionView
+============
+
+.. autoclass:: einspect.views.view_function.FunctionView
+   :members:
+   :inherited-members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
 project = "einspect"
 copyright = "2023, Ionite"
 author = "Ionite"
-release = "v0.5.3"
+release = "v0.5.4"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "einspect"
-version = "0.5.3"
+version = "0.5.4"
 packages = [{ include = "einspect", from = "src" }]
 description = "Extended Inspect - view and modify memory structs of runtime objects."
 authors = ["ionite34 <dev@ionite.io>"]

--- a/src/einspect/__init__.py
+++ b/src/einspect/__init__.py
@@ -14,6 +14,6 @@ einspect._patch.run()
 
 __all__ = ("view", "unsafe", "impl", "orig", "ptr", "NULL")
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 
 unsafe: ContextManager[None] = global_unsafe

--- a/src/einspect/structs/__init__.py
+++ b/src/einspect/structs/__init__.py
@@ -11,6 +11,7 @@ from einspect.structs.py_float import PyFloatObject
 from einspect.structs.py_list import PyListObject
 from einspect.structs.py_tuple import PyTupleObject
 from einspect.structs.py_set import PySetObject, SetEntry
+from einspect.structs.py_cfunction import PyCFunctionObject
 
 # Req before PyMappingProxyObject
 from einspect.structs.py_dict import PyDictObject, PyDictKeysObject, PyDictValues
@@ -60,6 +61,7 @@ __all__ = (
     "PyFloatObject",
     "PyUnicodeObject",
     "PyFunctionObject",
+    "PyCFunctionObject",
     "State",
     "Kind",
     "PyCompactUnicodeObject",

--- a/src/einspect/structs/include/methodobject_h.py
+++ b/src/einspect/structs/include/methodobject_h.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from ctypes import PYFUNCTYPE, Structure, c_char, c_char_p, c_int, py_object
+from ctypes import PYFUNCTYPE, Structure, c_char_p, c_int, py_object
 
 from typing_extensions import Annotated
 
@@ -13,7 +13,7 @@ PyCFunction = PYFUNCTYPE(py_object, py_object, py_object)
 
 @struct
 class PyMethodDef(Structure):
-    ml_name: c_char
+    ml_name: Annotated[bytes, c_char_p]
     ml_meth: PyCFunction
     ml_flags: Annotated[int, c_int]
-    ml_doc: c_char_p
+    ml_doc: Annotated[bytes, c_char_p]

--- a/src/einspect/structs/py_cfunction.py
+++ b/src/einspect/structs/py_cfunction.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from types import BuiltinFunctionType
+from typing import Callable, TypeVar
+
+from einspect.structs.deco import struct
+from einspect.structs.include.methodobject_h import PyMethodDef
+from einspect.structs.include.object_h import vectorcallfunc
+from einspect.structs.py_object import PyObject
+from einspect.types import ptr
+
+_T = TypeVar("_T", BuiltinFunctionType, Callable)
+
+
+@struct
+class PyCFunctionObject(PyObject[_T, None, None]):
+    m_ml: ptr[PyMethodDef]  # Description of the C function to call
+    m_self: ptr[PyObject]  # Passed as 'self' arg to the C func, can be NULL
+    m_module: ptr[PyObject]  # The __module__ attribute, can be anything
+    m_weakreflist: ptr[PyObject]  # List of weak references
+    vectorcall: vectorcallfunc
+
+    @classmethod
+    def from_object(cls, obj: _T) -> PyCFunctionObject[_T]:
+        return super().from_object(obj)  # type: ignore

--- a/src/einspect/structs/py_list.py
+++ b/src/einspect/structs/py_list.py
@@ -28,7 +28,7 @@ class PyListObject(PyVarObject[list, None, _VT], IsGC):
 
     @classmethod
     def from_object(cls, obj: list[_VT]) -> PyListObject[_VT]:
-        return cls.from_address(id(obj))
+        return super().from_object(obj)  # type: ignore
 
     def _format_fields_(self) -> Fields:
         return {

--- a/src/einspect/views/__init__.py
+++ b/src/einspect/views/__init__.py
@@ -1,5 +1,6 @@
 from einspect.views.view_base import AnyView, VarView, View
 from einspect.views.view_bool import BoolView
+from einspect.views.view_cfunction import CFunctionView
 from einspect.views.view_dict import DictView
 from einspect.views.view_float import FloatView
 from einspect.views.view_function import FunctionView
@@ -19,6 +20,7 @@ __all__ = (
     "DictView",
     "FloatView",
     "FunctionView",
+    "CFunctionView",
     "IntView",
     "ListView",
     "MappingProxyView",

--- a/src/einspect/views/factory.py
+++ b/src/einspect/views/factory.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from types import FunctionType, MappingProxyType
+from types import BuiltinFunctionType, FunctionType, MappingProxyType
 from typing import Any, Final, TypeVar, overload
 
+from einspect.views import CFunctionView
 from einspect.views.view_base import REF_DEFAULT, View
 from einspect.views.view_bool import BoolView
 from einspect.views.view_dict import DictView
@@ -29,10 +30,11 @@ VIEW_TYPES: Final[dict[type, type[View]]] = {
     str: StrView,
     list: ListView,
     tuple: TupleView,
-    dict: DictView,
     set: SetView,
-    FunctionType: FunctionView,
+    dict: DictView,
     MappingProxyType: MappingProxyView,
+    FunctionType: FunctionView,
+    BuiltinFunctionType: CFunctionView,
 }
 """Mapping of (type): (view class)."""
 
@@ -99,8 +101,12 @@ def view(obj: float, ref: bool = REF_DEFAULT) -> FloatView:
     ...
 
 
+# Ideally we'd have separate overloads for builtin vs user-defined functions,
+# but typeshed only defines builtin functions as Callable.
 @overload
-def view(obj: FunctionType | Callable, ref: bool = REF_DEFAULT) -> FunctionView:
+def view(
+    obj: BuiltinFunctionType | FunctionType | Callable, ref: bool = REF_DEFAULT
+) -> FunctionView | CFunctionView:
     ...
 
 

--- a/src/einspect/views/view_cfunction.py
+++ b/src/einspect/views/view_cfunction.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from types import BuiltinFunctionType
+from typing import Any
+
+from einspect.structs import PyCFunctionObject
+from einspect.structs.include.methodobject_h import PyMethodDef
+from einspect.structs.include.object_h import vectorcallfunc
+from einspect.structs.py_object import py_get, py_set
+from einspect.structs.traits import IsGC
+from einspect.views.unsafe import unsafe
+from einspect.views.view_base import View
+
+__all__ = ("CFunctionView",)
+
+
+class CFunctionView(View[BuiltinFunctionType, None, None], IsGC):
+    _pyobject: PyCFunctionObject
+
+    def __init__(self, obj: BuiltinFunctionType | Callable, ref: bool = False) -> None:
+        super().__init__(obj, ref)
+
+    @property
+    def ml(self) -> PyMethodDef:
+        return self._pyobject.m_ml.contents
+
+    # noinspection PyPropertyDefinition, PyMethodParameters
+    @property
+    def self(__self):
+        return py_get(__self._pyobject.m_self)
+
+    # noinspection PyPropertyDefinition, PyMethodParameters
+    @self.setter
+    @unsafe
+    def self(__self, value):
+        """Passed as 'self' arg to the C func."""
+        py_set(__self._pyobject.m_self, value)
+
+    @property
+    def module(self) -> str:
+        """The __module__ attribute, can be anything."""
+        return self._pyobject.m_module.contents.into_object()
+
+    @module.setter
+    def module(self, value: str) -> None:
+        py_set(self._pyobject.m_module, value)
+
+    @property
+    def weakreflist(self) -> Any:
+        """Weak reference list"""
+        return self._pyobject.m_weakreflist.contents.into_object()
+
+    @weakreflist.setter
+    def weakreflist(self, value: Any) -> None:
+        py_set(self._pyobject.m_weakreflist, value)
+
+    @property
+    def vectorcall(self) -> vectorcallfunc:
+        """Vectorcall function"""
+        return self._pyobject.vectorcall
+
+    @vectorcall.setter
+    @unsafe
+    def vectorcall(self, value: Callable) -> None:
+        self._pyobject.vectorcall = vectorcallfunc(value)

--- a/src/einspect/views/view_cfunction.py
+++ b/src/einspect/views/view_cfunction.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from types import BuiltinFunctionType
-from typing import Any
+from typing import Any, TypeVar
 
 from einspect.structs import PyCFunctionObject
 from einspect.structs.include.methodobject_h import PyMethodDef
@@ -14,11 +14,13 @@ from einspect.views.view_base import View
 
 __all__ = ("CFunctionView",)
 
+_T = TypeVar("_T", BuiltinFunctionType, Callable)
 
-class CFunctionView(View[BuiltinFunctionType, None, None], IsGC):
-    _pyobject: PyCFunctionObject
 
-    def __init__(self, obj: BuiltinFunctionType | Callable, ref: bool = False) -> None:
+class CFunctionView(View[_T, None, None], IsGC):
+    _pyobject: PyCFunctionObject[_T]
+
+    def __init__(self, obj: _T, ref: bool = False) -> None:
         super().__init__(obj, ref)
 
     @property

--- a/src/einspect/views/view_function.py
+++ b/src/einspect/views/view_function.py
@@ -8,13 +8,14 @@ from einspect.compat import Version
 from einspect.structs import PyFunctionObject
 from einspect.structs.include.object_h import vectorcallfunc
 from einspect.structs.py_object import py_get, py_set
+from einspect.structs.traits import IsGC
 from einspect.views.unsafe import unsafe
 from einspect.views.view_base import View
 
 __all__ = ("FunctionView",)
 
 
-class FunctionView(View[FunctionType, None, None]):
+class FunctionView(View[FunctionType, None, None], IsGC):
     _pyobject: PyFunctionObject
 
     def __init__(self, obj: FunctionType | Callable, ref: bool = False) -> None:

--- a/tests/views/test_view_cfunction.py
+++ b/tests/views/test_view_cfunction.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from types import BuiltinFunctionType
+
+from einspect.views import CFunctionView
+from tests.views.test_view_base import TestView
+
+
+class TestCFunctionView(TestView):
+    view_type = CFunctionView
+    obj_type = BuiltinFunctionType
+
+    def get_obj(self) -> BuiltinFunctionType:
+        return abs  # type: ignore
+
+    def test_attrs(self):
+        fn = self.get_obj()
+        v = self.view_type(fn)
+
+        assert v.ml.ml_name == fn.__name__.encode()
+        assert v.ml.ml_doc.decode().endswith(fn.__doc__)
+        assert v.self == fn.__self__
+        assert v.module == fn.__module__
+        assert v.weakreflist == v._pyobject.m_weakreflist.contents.into_object()

--- a/tests/views/test_view_str.py
+++ b/tests/views/test_view_str.py
@@ -24,6 +24,15 @@ class TestStrView(TestView):
         assert v.buffer[0] == ord("🤔")
         assert isinstance(v._pyobject, PyCompactUnicodeObject)
 
+    def test_unicode_subclass(self) -> None:
+        class UserStr(str):
+            pass
+
+        s = UserStr("curious 🤔")
+        v = view(s)
+        assert v.buffer[:9] == [*map(ord, "curious 🤔")]
+        assert isinstance(v._pyobject, PyCompactUnicodeObject)
+
     def test_properties(self) -> None:
         text = self.get_obj()
         v = view(text)


### PR DESCRIPTION
## Adds
- CFunctionView 
- PyCFunctionObject

for use with builtin functions like `id(), print(), abs()`, etc.