### PR TITLE
Fix FunctionView.version naming

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    name: Docs Check
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   build:
+    name: Docs Deploy
     runs-on: ubuntu-latest
 
     steps:

--- a/src/einspect/views/view_function.py
+++ b/src/einspect/views/view_function.py
@@ -147,18 +147,18 @@ class FunctionView(View[FunctionType, None, None], IsGC):
         self._pyobject.vectorcall = vectorcallfunc(value)
 
     @property
-    def func_version(self) -> int:
+    def version(self) -> int:
         if Version.PY_3_11.below():
             raise AttributeError(
-                "PyFunctionObject does not have func_version below Python 3.11"
+                "PyFunctionObject does not have version below Python 3.11"
             )
         return self._pyobject.func_version
 
-    @func_version.setter
+    @version.setter
     @unsafe
-    def func_version(self, value: int) -> None:
+    def version(self, value: int) -> None:
         if Version.PY_3_11.below():
             raise AttributeError(
-                "PyFunctionObject does not have func_version below Python 3.11"
+                "PyFunctionObject does not have version below Python 3.11"
             )
         self._pyobject.func_version = value

--- a/tests/views/test_view_function.py
+++ b/tests/views/test_view_function.py
@@ -47,6 +47,14 @@ class TestFunctionView(TestView):
         v = self.view_type(obj)
         assert v.builtins == obj.__globals__["__builtins__"]
 
+    @pytest.mark.skipif(sys.version_info < (3, 11), reason="Python 3.11+ only")
+    def test_version(self):
+        obj = self.get_obj()
+        v = self.view_type(obj)
+        assert v.version == v._pyobject.func_version
+        with v.unsafe():
+            v.version = v._pyobject.func_version
+
     def test_globals(self):
         # noinspection PyUnresolvedReferences
         def foo():

--- a/tests/views/test_view_function.py
+++ b/tests/views/test_view_function.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from types import FunctionType
+from unittest.mock import patch
 
 import pytest
 
@@ -54,6 +55,16 @@ class TestFunctionView(TestView):
         assert v.version == v._pyobject.func_version
         with v.unsafe():
             v.version = v._pyobject.func_version
+
+    @patch("einspect.compat.sys.version_info", (3, 10))
+    def test_version_error(self):
+        """FunctionView.version should raise AttributeError on Python < 3.11"""
+        obj = self.get_obj()
+        v = self.view_type(obj)
+        with pytest.raises(AttributeError):
+            _ = v.version
+        with pytest.raises(AttributeError), v.unsafe():
+            v.version = 0
 
     def test_globals(self):
         # noinspection PyUnresolvedReferences


### PR DESCRIPTION
## Fixes
- Changed inconsistent naming from `func_version` back to expected of `version`
- Added unit tests for `FunctionView.version` and related version-compatibility flows