### PR TITLE
Add multiple attribute option for `TypeView.__setitem__`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
 project = "einspect"
 copyright = "2023, Ionite"
 author = "Ionite"
-release = "v0.5.6"
+release = "v0.5.7"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "einspect"
-version = "0.5.6"
+version = "0.5.7"
 packages = [{ include = "einspect", from = "src" }]
 description = "Extended Inspect - view and modify memory structs of runtime objects."
 authors = ["ionite34 <dev@ionite.io>"]

--- a/src/einspect/__init__.py
+++ b/src/einspect/__init__.py
@@ -14,6 +14,6 @@ einspect._patch.run()
 
 __all__ = ("view", "unsafe", "impl", "orig", "ptr", "NULL")
 
-__version__ = "0.5.6"
+__version__ = "0.5.7"
 
 unsafe: ContextManager[None] = global_unsafe

--- a/tests/test_impl.py
+++ b/tests/test_impl.py
@@ -15,6 +15,17 @@ def test_impl_new_func():
     assert (10)._foo_fn(5) == "15"
 
 
+def test_impl_cache():
+    @impl(int)
+    def _foo_fn(self, x: int) -> str:
+        return str(self + x)
+
+    impl(int)(_foo_fn)
+
+    # noinspection PyUnresolvedReferences
+    assert (10)._foo_fn(5) == "15"
+
+
 def test_impl_new_property():
     @impl(int)
     @property


### PR DESCRIPTION
Supports supplying multiple string attributes to set all given names to the same value
```python
from einspect import view

view(str)["foo", "bar"] = lambda x: x * 2

print("abc".foo())
# abcabc
print("abc".bar())
# abcabc
```