### PR TITLE
Add `restore` and `__delitem__` for `TypeView`, `View.address` property, internal improvements of struct construction

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
 project = "einspect"
 copyright = "2023, Ionite"
 author = "Ionite"
-release = "v0.5.10"
+release = "v0.5.11"
 
 
 # -- General configuration ---------------------------------------------------

--- a/poetry.lock
+++ b/poetry.lock
@@ -813,14 +813,14 @@ sphinx-basic-ng = "*"
 
 [[package]]
 name = "identify"
-version = "2.5.17"
+version = "2.5.18"
 description = "File identification library for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "identify-2.5.17-py2.py3-none-any.whl", hash = "sha256:7d526dd1283555aafcc91539acc061d8f6f59adb0a7bba462735b0a318bff7ed"},
-    {file = "identify-2.5.17.tar.gz", hash = "sha256:93cc61a861052de9d4c541a7acb7e3dcc9c11b398a2144f6e52ae5285f5f4f06"},
+    {file = "identify-2.5.18-py2.py3-none-any.whl", hash = "sha256:93aac7ecf2f6abf879b8f29a8002d3c6de7086b8c28d88e1ad15045a15ab63f9"},
+    {file = "identify-2.5.18.tar.gz", hash = "sha256:89e144fa560cc4cffb6ef2ab5e9fb18ed9f9b3cb054384bab4b95c12f6c309fe"},
 ]
 
 [package.extras]
@@ -903,14 +903,14 @@ files = [
 
 [[package]]
 name = "ipykernel"
-version = "6.21.1"
+version = "6.21.2"
 description = "IPython Kernel for Jupyter"
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "ipykernel-6.21.1-py3-none-any.whl", hash = "sha256:1a04bb359212e23e46adc0116ec82ea128c1e5bd532fde4fbe679787ff36f0cf"},
-    {file = "ipykernel-6.21.1.tar.gz", hash = "sha256:a0f8eece39cab1ee352c9b59ec67bbe44d8299f8238e4c16ff7f4cf0052d3378"},
+    {file = "ipykernel-6.21.2-py3-none-any.whl", hash = "sha256:430d00549b6aaf49bd0f5393150691edb1815afa62d457ee6b1a66b25cb17874"},
+    {file = "ipykernel-6.21.2.tar.gz", hash = "sha256:6e9213484e4ce1fb14267ee435e18f23cc3a0634e635b9fb4ed4677b84e0fdf8"},
 ]
 
 [package.dependencies]
@@ -924,7 +924,7 @@ matplotlib-inline = ">=0.1"
 nest-asyncio = "*"
 packaging = "*"
 psutil = "*"
-pyzmq = ">=17"
+pyzmq = ">=20"
 tornado = ">=6.1"
 traitlets = ">=5.4.0"
 
@@ -1150,14 +1150,14 @@ test = ["codecov", "coverage", "ipykernel (>=6.14)", "mypy", "paramiko", "pre-co
 
 [[package]]
 name = "jupyter-console"
-version = "6.5.0"
+version = "6.5.1"
 description = "Jupyter terminal console"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "jupyter_console-6.5.0-py3-none-any.whl", hash = "sha256:87826ab6c8c418731fd78f14ec504df735e79554e35784d0a6379018bb3ef9d7"},
-    {file = "jupyter_console-6.5.0.tar.gz", hash = "sha256:67e68f1da16bc3f6f78ed846dd5543ec0679369f8504734f10bfd206faae39ea"},
+    {file = "jupyter_console-6.5.1-py3-none-any.whl", hash = "sha256:c575bb6ed56ca78189594176341e7b31426ff30fafcd22bf3dad7be309595b5e"},
+    {file = "jupyter_console-6.5.1.tar.gz", hash = "sha256:6b91b7b6e8a715053b536db209a2f4b02429d7b28db27373a56a26b0bebd620b"},
 ]
 
 [package.dependencies]
@@ -2140,14 +2140,14 @@ six = ">=1.5"
 
 [[package]]
 name = "python-json-logger"
-version = "2.0.4"
+version = "2.0.6"
 description = "A python library adding a json log formatter"
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 files = [
-    {file = "python-json-logger-2.0.4.tar.gz", hash = "sha256:764d762175f99fcc4630bd4853b09632acb60a6224acb27ce08cd70f0b1b81bd"},
-    {file = "python_json_logger-2.0.4-py3-none-any.whl", hash = "sha256:3b03487b14eb9e4f77e4fc2a023358b5394b82fd89cecf5586259baed57d8c6f"},
+    {file = "python-json-logger-2.0.6.tar.gz", hash = "sha256:ed33182c2b438a366775c25c1219ebbd5bd7f71694c644d6b3b3861e19565ae3"},
+    {file = "python_json_logger-2.0.6-py3-none-any.whl", hash = "sha256:3af8e5b907b4a5b53cae249205ee3a3d3472bd7ad9ddfaec136eec2f2faf4995"},
 ]
 
 [[package]]
@@ -2474,14 +2474,14 @@ win32 = ["pywin32"]
 
 [[package]]
 name = "setuptools"
-version = "67.2.0"
+version = "67.3.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.2.0-py3-none-any.whl", hash = "sha256:16ccf598aab3b506593c17378473978908a2734d7336755a8769b480906bec1c"},
-    {file = "setuptools-67.2.0.tar.gz", hash = "sha256:b440ee5f7e607bb8c9de15259dba2583dd41a38879a7abc1d43a71c59524da48"},
+    {file = "setuptools-67.3.1-py3-none-any.whl", hash = "sha256:23c86b4e44432bfd8899384afc08872ec166a24f48a3f99f293b0a557e6a6b5d"},
+    {file = "setuptools-67.3.1.tar.gz", hash = "sha256:daec07fd848d80676694d6bf69c009d28910aeece68a38dbe88b7e1bb6dba12e"},
 ]
 
 [package.extras]
@@ -2527,14 +2527,14 @@ files = [
 
 [[package]]
 name = "soupsieve"
-version = "2.3.2.post1"
+version = "2.4"
 description = "A modern CSS selector implementation for Beautiful Soup."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "soupsieve-2.3.2.post1-py3-none-any.whl", hash = "sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759"},
-    {file = "soupsieve-2.3.2.post1.tar.gz", hash = "sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d"},
+    {file = "soupsieve-2.4-py3-none-any.whl", hash = "sha256:49e5368c2cda80ee7e84da9dbe3e110b70a4575f196efb74e51b94549d921955"},
+    {file = "soupsieve-2.4.tar.gz", hash = "sha256:e28dba9ca6c7c00173e34e4ba57448f0688bb681b7c5e8bf4971daafc093d69a"},
 ]
 
 [[package]]
@@ -2836,14 +2836,14 @@ test = ["argcomplete (>=2.0)", "pre-commit", "pytest", "pytest-mock"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.4.0"
+version = "4.5.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
-    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
+    {file = "typing_extensions-4.5.0-py3-none-any.whl", hash = "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"},
+    {file = "typing_extensions-4.5.0.tar.gz", hash = "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb"},
 ]
 
 [[package]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -937,14 +937,14 @@ test = ["flaky", "ipyparallel", "pre-commit", "pytest (>=7.0)", "pytest-asyncio"
 
 [[package]]
 name = "ipython"
-version = "8.9.0"
+version = "8.10.0"
 description = "IPython: Productive Interactive Computing"
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "ipython-8.9.0-py3-none-any.whl", hash = "sha256:9c207b0ef2d276d1bfcfeb9a62804336abbe4b170574ea061500952319b1d78c"},
-    {file = "ipython-8.9.0.tar.gz", hash = "sha256:71618e82e6d59487bea059626e7c79fb4a5b760d1510d02fab1160db6fdfa1f7"},
+    {file = "ipython-8.10.0-py3-none-any.whl", hash = "sha256:b38c31e8fc7eff642fc7c597061fff462537cf2314e3225a19c906b7b0d8a345"},
+    {file = "ipython-8.10.0.tar.gz", hash = "sha256:b13a1d6c1f5818bd388db53b7107d17454129a70de2b87481d555daede5eb49e"},
 ]
 
 [package.dependencies]
@@ -962,7 +962,7 @@ stack-data = "*"
 traitlets = ">=5"
 
 [package.extras]
-all = ["black", "curio", "docrepr", "ipykernel", "ipyparallel", "ipywidgets", "matplotlib", "matplotlib (!=3.2.0)", "nbconvert", "nbformat", "notebook", "numpy (>=1.20)", "pandas", "pytest (<7)", "pytest (<7.1)", "pytest-asyncio", "qtconsole", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "stack-data", "testpath", "trio", "typing-extensions"]
+all = ["black", "curio", "docrepr", "ipykernel", "ipyparallel", "ipywidgets", "matplotlib", "matplotlib (!=3.2.0)", "nbconvert", "nbformat", "notebook", "numpy (>=1.21)", "pandas", "pytest (<7)", "pytest (<7.1)", "pytest-asyncio", "qtconsole", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "stack-data", "testpath", "trio", "typing-extensions"]
 black = ["black"]
 doc = ["docrepr", "ipykernel", "matplotlib", "pytest (<7)", "pytest (<7.1)", "pytest-asyncio", "setuptools (>=18.5)", "sphinx (>=1.3)", "sphinx-rtd-theme", "stack-data", "testpath", "typing-extensions"]
 kernel = ["ipykernel"]
@@ -972,7 +972,7 @@ notebook = ["ipywidgets", "notebook"]
 parallel = ["ipyparallel"]
 qtconsole = ["qtconsole"]
 test = ["pytest (<7.1)", "pytest-asyncio", "testpath"]
-test-extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.20)", "pandas", "pytest (<7.1)", "pytest-asyncio", "testpath", "trio"]
+test-extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.21)", "pandas", "pytest (<7.1)", "pytest-asyncio", "testpath", "trio"]
 
 [[package]]
 name = "ipython-genutils"
@@ -1150,25 +1150,28 @@ test = ["codecov", "coverage", "ipykernel (>=6.14)", "mypy", "paramiko", "pre-co
 
 [[package]]
 name = "jupyter-console"
-version = "6.4.4"
+version = "6.5.0"
 description = "Jupyter terminal console"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "jupyter_console-6.4.4-py3-none-any.whl", hash = "sha256:756df7f4f60c986e7bc0172e4493d3830a7e6e75c08750bbe59c0a5403ad6dee"},
-    {file = "jupyter_console-6.4.4.tar.gz", hash = "sha256:172f5335e31d600df61613a97b7f0352f2c8250bbd1092ef2d658f77249f89fb"},
+    {file = "jupyter_console-6.5.0-py3-none-any.whl", hash = "sha256:87826ab6c8c418731fd78f14ec504df735e79554e35784d0a6379018bb3ef9d7"},
+    {file = "jupyter_console-6.5.0.tar.gz", hash = "sha256:67e68f1da16bc3f6f78ed846dd5543ec0679369f8504734f10bfd206faae39ea"},
 ]
 
 [package.dependencies]
-ipykernel = "*"
+ipykernel = ">=6.14"
 ipython = "*"
 jupyter-client = ">=7.0.0"
-prompt-toolkit = ">=2.0.0,<3.0.0 || >3.0.0,<3.0.1 || >3.0.1,<3.1.0"
+jupyter-core = ">=4.12,<5.0.0 || >=5.1.0"
+prompt-toolkit = ">=3.0.30"
 pygments = "*"
+pyzmq = ">=17"
+traitlets = ">=5.4"
 
 [package.extras]
-test = ["pexpect"]
+test = ["pexpect", "pytest"]
 
 [[package]]
 name = "jupyter-core"
@@ -1835,19 +1838,19 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "2.6.2"
+version = "3.0.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-2.6.2-py3-none-any.whl", hash = "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490"},
-    {file = "platformdirs-2.6.2.tar.gz", hash = "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"},
+    {file = "platformdirs-3.0.0-py3-none-any.whl", hash = "sha256:b1d5eb14f221506f50d6604a561f4c5786d9e80355219694a1b244bcd96f4567"},
+    {file = "platformdirs-3.0.0.tar.gz", hash = "sha256:8a1228abb1ef82d788f74139988b137e78692984ec7b08eaa6c65f1723af28f9"},
 ]
 
 [package.extras]
-docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
+docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.22,!=1.23.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "pluggy"
@@ -2101,14 +2104,14 @@ testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtuale
 
 [[package]]
 name = "pytest-xdist"
-version = "3.1.0"
+version = "3.2.0"
 description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-xdist-3.1.0.tar.gz", hash = "sha256:40fdb8f3544921c5dfcd486ac080ce22870e71d82ced6d2e78fa97c2addd480c"},
-    {file = "pytest_xdist-3.1.0-py3-none-any.whl", hash = "sha256:70a76f191d8a1d2d6be69fc440cdf85f3e4c03c08b520fd5dc5d338d6cf07d89"},
+    {file = "pytest-xdist-3.2.0.tar.gz", hash = "sha256:fa10f95a2564cd91652f2d132725183c3b590d9fdcdec09d3677386ecf4c1ce9"},
+    {file = "pytest_xdist-3.2.0-py3-none-any.whl", hash = "sha256:336098e3bbd8193276867cc87db8b22903c3927665dff9d1ac8684c02f597b68"},
 ]
 
 [package.dependencies]
@@ -2877,20 +2880,20 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.18.0"
+version = "20.19.0"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.18.0-py3-none-any.whl", hash = "sha256:9d61e4ec8d2c0345dab329fb825eb05579043766a4b26a2f66b28948de68c722"},
-    {file = "virtualenv-20.18.0.tar.gz", hash = "sha256:f262457a4d7298a6b733b920a196bf8b46c8af15bf1fd9da7142995eff15118e"},
+    {file = "virtualenv-20.19.0-py3-none-any.whl", hash = "sha256:54eb59e7352b573aa04d53f80fc9736ed0ad5143af445a1e539aada6eb947dd1"},
+    {file = "virtualenv-20.19.0.tar.gz", hash = "sha256:37a640ba82ed40b226599c522d411e4be5edb339a0c0de030c0dc7b646d61590"},
 ]
 
 [package.dependencies]
 distlib = ">=0.3.6,<1"
 filelock = ">=3.4.1,<4"
-platformdirs = ">=2.4,<3"
+platformdirs = ">=2.4,<4"
 
 [package.extras]
 docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=22.12)"]
@@ -2963,14 +2966,14 @@ files = [
 
 [[package]]
 name = "zipp"
-version = "3.12.1"
+version = "3.13.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "zipp-3.12.1-py3-none-any.whl", hash = "sha256:6c4fe274b8f85ec73c37a8e4e3fa00df9fb9335da96fb789e3b96b318e5097b3"},
-    {file = "zipp-3.12.1.tar.gz", hash = "sha256:a3cac813d40993596b39ea9e93a18e8a2076d5c378b8bc88ec32ab264e04ad02"},
+    {file = "zipp-3.13.0-py3-none-any.whl", hash = "sha256:e8b2a36ea17df80ffe9e2c4fda3f693c3dad6df1697d3cd3af232db680950b0b"},
+    {file = "zipp-3.13.0.tar.gz", hash = "sha256:23f70e964bc11a34cef175bc90ba2914e1e4545ea1e3e2f67c079671883f9cb6"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "einspect"
-version = "0.5.10"
+version = "0.5.11"
 packages = [{ include = "einspect", from = "src" }]
 description = "Extended Inspect - view and modify memory structs of runtime objects."
 authors = ["ionite34 <dev@ionite.io>"]

--- a/src/einspect/__init__.py
+++ b/src/einspect/__init__.py
@@ -12,6 +12,6 @@ einspect._patch.run()
 
 __all__ = ("view", "unsafe", "impl", "orig", "ptr", "NULL")
 
-__version__ = "0.5.10"
+__version__ = "0.5.11"
 
 unsafe = global_unsafe

--- a/src/einspect/_compat/py_function_3_10.py
+++ b/src/einspect/_compat/py_function_3_10.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 from types import FunctionType
 
-from einspect.structs.deco import struct
 from einspect.structs.include.object_h import vectorcallfunc
 from einspect.structs.py_object import PyObject
 from einspect.types import ptr
 
 
-@struct
 class PyFunctionObject(PyObject[FunctionType, None, None]):
     globals: ptr[PyObject]
     builtins: ptr[PyObject]

--- a/src/einspect/_compat/py_function_3_9.py
+++ b/src/einspect/_compat/py_function_3_9.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 from types import FunctionType
 
-from einspect.structs.deco import struct
 from einspect.structs.include.object_h import vectorcallfunc
 from einspect.structs.py_object import PyObject
 from einspect.types import ptr
 
 
-@struct
 class PyFunctionObject(PyObject[FunctionType, None, None]):
     code: ptr[PyObject]  # A code object, the __code__ attribute
     globals: ptr[PyObject]

--- a/src/einspect/_compat/py_unicode_3_12.py
+++ b/src/einspect/_compat/py_unicode_3_12.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from ctypes import (
-    Union,
     addressof,
     c_char,
     c_char_p,
@@ -22,7 +21,7 @@ from typing_extensions import Annotated
 
 from einspect.api import Py_hash_t
 from einspect.protocols import bind_api
-from einspect.structs.deco import struct
+from einspect.structs.deco import Union
 from einspect.structs.py_object import Fields, PyObject
 from einspect.structs.traits import IsGC
 from einspect.types import Array, char_p, ptr, void_p
@@ -103,7 +102,6 @@ class Kind(IntEnum):
         return types_map[int(self)]
 
 
-@struct
 class LegacyUnion(Union):
     any: void_p
     latin1: ptr[c_uint8]  # Py_UCS1
@@ -111,7 +109,6 @@ class LegacyUnion(Union):
     ucs4: ptr[c_uint32]  # Py_UCS4
 
 
-@struct
 class PyASCIIObject(PyObject[str, None, None], IsGC):
     """
     Defines a PyUnicodeObject Structure
@@ -205,7 +202,6 @@ class PyASCIIObject(PyObject[str, None, None], IsGC):
         """Return the length of the string in code points."""
 
 
-@struct
 class PyCompactUnicodeObject(PyASCIIObject):
     """
     Defines a PyCompactUnicodeObject Structure
@@ -226,7 +222,6 @@ class PyCompactUnicodeObject(PyASCIIObject):
         }
 
 
-@struct
 class PyUnicodeObject(PyCompactUnicodeObject):
     """Defines a PyUnicodeObject Structure."""
 

--- a/src/einspect/_patch.py
+++ b/src/einspect/_patch.py
@@ -6,6 +6,7 @@ from ctypes import POINTER, addressof, c_void_p, memmove, sizeof
 
 from einspect import types
 from einspect.structs.py_object import PyObject
+from einspect.types import PyCFuncPtrType
 
 
 class _Null_LP_PyObject(POINTER(PyObject)):
@@ -18,9 +19,13 @@ class _Null_LP_PyObject(POINTER(PyObject)):
     def __eq__(self, other) -> bool:
         """Returns equal to other null pointers."""
         # noinspection PyUnresolvedReferences
-        if not isinstance(other, ctypes._Pointer):
-            return NotImplemented
-        return not other
+        if isinstance(other, ctypes._Pointer):
+            return not other
+
+        if isinstance(type(other), PyCFuncPtrType):
+            return not ctypes.cast(other, c_void_p)
+
+        return NotImplemented
 
 
 def run() -> None:

--- a/src/einspect/_patch.py
+++ b/src/einspect/_patch.py
@@ -14,7 +14,7 @@ class _Null_LP_PyObject(POINTER(PyObject)):
 
     def __repr__(self) -> str:
         """Returns the string representation of the pointer."""
-        return f"<NULL ptr[PyObject] at {addressof(self):#04x}>"
+        return f"<Null LP_PyObject at {addressof(self):#04x}>"
 
     def __eq__(self, other) -> bool:
         """Returns equal to other null pointers."""

--- a/src/einspect/_patch.py
+++ b/src/einspect/_patch.py
@@ -6,7 +6,7 @@ from ctypes import POINTER, addressof, c_void_p, memmove, sizeof
 
 from einspect import types
 from einspect.structs.py_object import PyObject
-from einspect.types import PyCFuncPtrType
+from einspect.types import Pointer, PyCFuncPtrType
 
 
 class _Null_LP_PyObject(POINTER(PyObject)):
@@ -18,8 +18,7 @@ class _Null_LP_PyObject(POINTER(PyObject)):
 
     def __eq__(self, other) -> bool:
         """Returns equal to other null pointers."""
-        # noinspection PyUnresolvedReferences
-        if isinstance(other, ctypes._Pointer):
+        if isinstance(other, Pointer):
             return not other
 
         if isinstance(type(other), PyCFuncPtrType):

--- a/src/einspect/protocols/type_parse.py
+++ b/src/einspect/protocols/type_parse.py
@@ -29,6 +29,7 @@ class FuncPtr(Protocol):
 
 
 aliases = {
+    bool: ctypes.c_bool,
     # ctypes will cast c_ssize_t to (int)
     int: Py_ssize_t,
     # ctypes will cast py_object to (object)

--- a/src/einspect/protocols/type_parse.py
+++ b/src/einspect/protocols/type_parse.py
@@ -10,6 +10,8 @@ from typing import Any, Protocol, Sequence, TypeVar, get_origin, runtime_checkab
 
 from typing_extensions import Self
 
+from einspect.types import _SelfPtr
+
 log = logging.getLogger(__name__)
 
 Py_ssize_t = ctypes.c_ssize_t
@@ -100,6 +102,12 @@ def convert_type_hints(source: type, owner_cls: type) -> type | None:
     # noinspection PyUnresolvedReferences, PyProtectedMember
     if isinstance(source, typing._GenericAlias):
         source = get_origin(source)
+
+    # For special SelfPtr object
+    if source is _SelfPtr:
+        res = POINTER(owner_cls)  # type: ignore
+        res.__module__ = owner_cls.__module__
+        return res
 
     if source in aliases:
         return aliases[source]

--- a/src/einspect/structs/deco.py
+++ b/src/einspect/structs/deco.py
@@ -132,7 +132,6 @@ class Struct(Structure, AsRef, Display, metaclass=StructMeta):
     def __setattr__(self, key, value):
         # Skip assignments that don't have a _fields_ entry
         if key in self._fields_map_:
-            log.debug(f"Found {key!r} in {self._fields_map_!r}")
             # Get the field type
             field_type = self._fields_map_[key][1]
 

--- a/src/einspect/structs/include/object_h.py
+++ b/src/einspect/structs/include/object_h.py
@@ -1,11 +1,11 @@
 """https://github.com/python/cpython/blob/3.11/Include/object.h"""
 from __future__ import annotations
 
-from ctypes import PYFUNCTYPE, Structure, c_char_p, c_int, c_void_p, py_object
+from ctypes import PYFUNCTYPE, c_char_p, c_int, c_void_p, py_object
 from enum import IntEnum
 
 from einspect.api import Py_ssize_t
-from einspect.structs.deco import struct
+from einspect.structs.deco import Struct
 from einspect.structs.include.pybuffer_h import getbufferproc, releasebufferproc
 from einspect.types import ptr
 
@@ -158,22 +158,19 @@ class TpFlags(IntEnum):
     HAVE_VERSION_TAG = 1 << 18
 
 
-@struct
-class PyAsyncMethods(Structure):
+class PyAsyncMethods(Struct):
     am_await: unaryfunc
     am_aiter: unaryfunc
     am_anext: unaryfunc
     am_send: sendfunc
 
 
-@struct
-class PyBufferProcs(Structure):
+class PyBufferProcs(Struct):
     bf_getbuffer: getbufferproc
     bf_releasebuffer: releasebufferproc
 
 
-@struct
-class PyNumberMethods(Structure):
+class PyNumberMethods(Struct):
     """
     Number implementations must check *both*
     arguments for proper type and implement the necessary conversions
@@ -222,15 +219,13 @@ class PyNumberMethods(Structure):
     nb_inplace_matrix_multiply: binaryfunc
 
 
-@struct
-class PyMappingMethods(Structure):
+class PyMappingMethods(Struct):
     mp_length: lenfunc
     mp_subscript: binaryfunc
     mp_ass_subscript: objobjargproc
 
 
-@struct
-class PySequenceMethods(Structure):
+class PySequenceMethods(Struct):
     sq_length: lenfunc
     sq_concat: binaryfunc
     sq_repeat: ssizeargfunc

--- a/src/einspect/structs/mapping_proxy.py
+++ b/src/einspect/structs/mapping_proxy.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from types import MappingProxyType
 from typing import TypeVar
 
-from einspect.structs.deco import struct
 from einspect.structs.py_dict import PyDictObject
 from einspect.structs.py_object import Fields, PyObject
 from einspect.structs.traits import IsGC
@@ -16,7 +15,6 @@ _KT = TypeVar("_KT")
 _VT_co = TypeVar("_VT_co", covariant=True)
 
 
-@struct
 class MappingProxyObject(PyObject[MappingProxyType, _KT, _VT_co], IsGC):
     """
     Defines a mappingproxyobject Structure.

--- a/src/einspect/structs/py_bool.py
+++ b/src/einspect/structs/py_bool.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
 from einspect.structs import PyLongObject
-from einspect.structs.deco import struct
 
 __all__ = ("PyBoolObject",)
 
 
-@struct
 class PyBoolObject(PyLongObject):
     """
     Defines a PyBoolObject Structure.

--- a/src/einspect/structs/py_cfunction.py
+++ b/src/einspect/structs/py_cfunction.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from types import BuiltinFunctionType
 from typing import Callable, TypeVar
 
-from einspect.structs.deco import struct
 from einspect.structs.include.methodobject_h import PyMethodDef
 from einspect.structs.include.object_h import vectorcallfunc
 from einspect.structs.py_object import PyObject
@@ -12,7 +11,6 @@ from einspect.types import ptr
 _T = TypeVar("_T", BuiltinFunctionType, Callable)
 
 
-@struct
 class PyCFunctionObject(PyObject[_T, None, None]):
     m_ml: ptr[PyMethodDef]  # Description of the C function to call
     m_self: ptr[PyObject]  # Passed as 'self' arg to the C func, can be NULL

--- a/src/einspect/structs/py_dict.py
+++ b/src/einspect/structs/py_dict.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from ctypes import (
     POINTER,
-    Structure,
     _SimpleCData,
     addressof,
     c_char,
@@ -20,9 +19,9 @@ from typing import Dict, TypeVar
 from typing_extensions import Annotated
 
 from einspect.protocols.delayed_bind import bind_api
-from einspect.structs.deco import struct
+from einspect.structs.deco import Struct
 from einspect.structs.py_object import Fields, PyObject
-from einspect.structs.traits import Display, IsGC
+from einspect.structs.traits import IsGC
 from einspect.types import Array, ptr
 
 __all__ = ("PyDictObject",)
@@ -32,8 +31,7 @@ _KT = TypeVar("_KT")
 _VT = TypeVar("_VT")
 
 
-@struct
-class PyDictKeysObject(Structure, Display):
+class PyDictKeysObject(Struct):
     """
     Defines a DictKeysObject Structure.
 
@@ -94,12 +92,10 @@ class PyDictKeysObject(Structure, Display):
         }
 
 
-@struct
-class PyDictValues(Structure, Display):
+class PyDictValues(Struct):
     values: ptr[PyObject]
 
 
-@struct
 class PyDictObject(PyObject[dict, _KT, _VT], IsGC):
     """
     Defines a PyDictObject Structure.

--- a/src/einspect/structs/py_float.py
+++ b/src/einspect/structs/py_float.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import ctypes
 
-from einspect.structs.deco import struct
 from einspect.structs.py_object import PyObject
 
 
-@struct
-class PyFloatObject(PyObject):
+class PyFloatObject(PyObject[float, None, None]):
     """
     Defines a PyFloatObject Structure.
 

--- a/src/einspect/structs/py_function.py
+++ b/src/einspect/structs/py_function.py
@@ -5,13 +5,11 @@ from types import FunctionType
 
 from typing_extensions import Annotated
 
-from einspect.structs.deco import struct
 from einspect.structs.include.object_h import vectorcallfunc
 from einspect.structs.py_object import PyObject
 from einspect.types import ptr
 
 
-@struct
 class PyFunctionObject(PyObject[FunctionType, None, None]):
     globals: ptr[PyObject]
     builtins: ptr[PyObject]

--- a/src/einspect/structs/py_gc.py
+++ b/src/einspect/structs/py_gc.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from ctypes import Structure, c_void_p, cast
+from ctypes import c_void_p, cast
 from enum import IntEnum
 
 from typing_extensions import Annotated
 
 from einspect.api import uintptr_t
-from einspect.structs.deco import struct
-from einspect.structs.traits import AsRef
+from einspect.structs.deco import Struct
 from einspect.types import ptr
 
 
@@ -23,8 +22,7 @@ class PyGC(IntEnum):
     PREV_MASK = uintptr_t(-1).value << PREV_SHIFT
 
 
-@struct
-class PyGC_Head(Structure, AsRef):
+class PyGC_Head(Struct):
     """
     Defines the PyGC_Head Structure.
 

--- a/src/einspect/structs/py_list.py
+++ b/src/einspect/structs/py_list.py
@@ -6,7 +6,6 @@ from typing import List, TypeVar
 from typing_extensions import Annotated
 
 from einspect.protocols.delayed_bind import bind_api
-from einspect.structs.deco import struct
 from einspect.structs.py_object import Fields, PyObject, PyVarObject
 from einspect.structs.traits import IsGC
 from einspect.types import ptr
@@ -14,8 +13,6 @@ from einspect.types import ptr
 _VT = TypeVar("_VT")
 
 
-# noinspection PyPep8Naming
-@struct
 class PyListObject(PyVarObject[list, None, _VT], IsGC):
     """
     Defines a PyListObject Structure.

--- a/src/einspect/structs/py_long.py
+++ b/src/einspect/structs/py_long.py
@@ -7,12 +7,10 @@ from ctypes import addressof, c_uint32, sizeof
 from typing_extensions import Annotated
 
 from einspect.api import seq_to_array
-from einspect.structs.deco import struct
 from einspect.structs.py_object import Fields, PyVarObject
 from einspect.types import Array
 
 
-@struct
 class PyLongObject(PyVarObject[int, None, None]):
     """
     Defines a PyLongObject Structure.

--- a/src/einspect/structs/py_object.py
+++ b/src/einspect/structs/py_object.py
@@ -111,7 +111,7 @@ class PyObject(Struct, AsRef, Generic[_T, _KT, _VT]):
         if "ob_type" not in kwargs:
             raise TypeError("Missing required keyword-argument field 'ob_type'")
 
-        new_ob_size: int = kwargs.get("ob_size", 0).__index__()
+        new_ob_size = kwargs.get("ob_size", 0).__index__()
         new_ob_type = PyTypeObject.try_from(kwargs["ob_type"])
 
         if issubclass(cls, IsGC):
@@ -126,6 +126,7 @@ class PyObject(Struct, AsRef, Generic[_T, _KT, _VT]):
                 if issubclass(cls, PyVarObject)
                 else new_ob_type.New()
             )
+
         return res.contents.astype(cls)
 
     @property

--- a/src/einspect/structs/py_object.py
+++ b/src/einspect/structs/py_object.py
@@ -24,7 +24,7 @@ from einspect.api import PTR_SIZE, address, align_size
 from einspect.compat import Version, python_req
 from einspect.protocols.delayed_bind import bind_api
 from einspect.protocols.type_parse import is_ctypes_type
-from einspect.structs.deco import struct
+from einspect.structs.deco import Struct
 from einspect.structs.py_gc import PyGC_Head
 from einspect.structs.traits import AsRef, IsGC
 from einspect.types import ptr
@@ -67,8 +67,7 @@ def py_set(obj_ptr: ptr[PyObject], value: object | PyObject | ptr[PyObject]) -> 
     obj_ptr.contents = PyObject.try_from(value).with_ref()
 
 
-@struct
-class PyObject(Structure, AsRef, Generic[_T, _KT, _VT]):
+class PyObject(Struct, AsRef, Generic[_T, _KT, _VT]):
     """Defines a base PyObject Structure."""
 
     ob_refcnt: int
@@ -321,7 +320,6 @@ def _PyObject__init__(self, *args, **kwargs) -> None:
 PyObject.__init__ = _PyObject__init__
 
 
-@struct
 class PyVarObject(PyObject[_T, _KT, _VT]):
     """
     Defines a base PyVarObject Structure.

--- a/src/einspect/structs/py_object.py
+++ b/src/einspect/structs/py_object.py
@@ -301,7 +301,15 @@ class PyObject(Struct, AsRef, Generic[_T, _KT, _VT]):
 
     @bind_api(pythonapi["PyObject_SetAttr"])
     def SetAttr(self, name: str, value: object) -> int:
-        """Set the attribute of the PyObject."""
+        """Set the attribute of the PyObject. Returns -1 on failure."""
+
+    @bind_api(pythonapi["PyObject_HasAttr"])
+    def HasAttr(self, name: str) -> bool:
+        """Return True if the PyObject has the attribute."""
+
+    def DelAttr(self, name: str) -> int:
+        """Delete attribute `name` of the PyObject. Returns -1 on failure."""
+        return self.SetAttr(name, ctypes.py_object())
 
 
 # We don't want this visible to type-checking but `PyObject.__init__`

--- a/src/einspect/structs/py_set.py
+++ b/src/einspect/structs/py_set.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-from ctypes import Structure
 from typing import Generic, TypeVar
 
 from typing_extensions import Annotated
 
 from einspect.api import Py_hash_t
-from einspect.structs.deco import struct
+from einspect.structs.deco import Struct
 from einspect.structs.py_object import Fields, PyObject
-from einspect.structs.traits import AsRef, IsGC
+from einspect.structs.traits import IsGC
 from einspect.types import ptr
 
 _T = TypeVar("_T")
@@ -17,8 +16,7 @@ PySet_MINSIZE = 8
 """https://github.com/python/cpython/blob/3.11/Include/cpython/setobject.h#L18"""
 
 
-@struct
-class SetEntry(Structure, AsRef, Generic[_T]):
+class SetEntry(Struct, Generic[_T]):
     key: ptr[PyObject[_T, None, None]]
     hash: Annotated[int, Py_hash_t]  # noqa: A003
 
@@ -30,8 +28,7 @@ class SetEntry(Structure, AsRef, Generic[_T]):
         }
 
 
-@struct
-class PySetObject(PyObject[set, None, _T], AsRef, IsGC):
+class PySetObject(PyObject[set, None, _T], IsGC):
     """
     Defines a PySetObject Structure.
 

--- a/src/einspect/structs/py_tuple.py
+++ b/src/einspect/structs/py_tuple.py
@@ -7,7 +7,6 @@ from typing import Any, TypeVar, overload
 
 from einspect.api import Py_ssize_t, seq_to_array
 from einspect.protocols.delayed_bind import bind_api
-from einspect.structs.deco import struct
 from einspect.structs.py_object import Fields, PyObject, PyVarObject
 from einspect.structs.traits import IsGC
 from einspect.types import Array, ptr
@@ -15,7 +14,6 @@ from einspect.types import Array, ptr
 _VT = TypeVar("_VT")
 
 
-@struct
 class PyTupleObject(PyVarObject[tuple, None, _VT], IsGC):
     """
     Defines a PyTupleObject Structure.

--- a/src/einspect/structs/py_type.py
+++ b/src/einspect/structs/py_type.py
@@ -19,7 +19,6 @@ from typing import Any, Type, TypeVar
 from typing_extensions import Annotated, Self
 
 from einspect.protocols import bind_api
-from einspect.structs.deco import struct
 from einspect.structs.include.descrobject_h import PyGetSetDef, PyMemberDef
 from einspect.structs.include.methodobject_h import PyMethodDef
 from einspect.structs.include.object_h import *
@@ -35,7 +34,6 @@ DEFAULT = object()
 
 
 # noinspection PyPep8Naming
-@struct
 class PyTypeObject(PyVarObject[_T, None, None]):
     """
     Defines a PyTypeObject Structure.

--- a/src/einspect/structs/py_unicode.py
+++ b/src/einspect/structs/py_unicode.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from ctypes import (
-    Union,
     addressof,
     c_char,
     c_char_p,
@@ -23,7 +22,7 @@ from typing_extensions import Annotated
 
 from einspect.api import Py_hash_t
 from einspect.protocols import bind_api
-from einspect.structs.deco import struct
+from einspect.structs.deco import Union
 from einspect.structs.py_object import Fields, PyObject
 from einspect.structs.traits import IsGC
 from einspect.types import Array, char_p, ptr, void_p, wchar_p
@@ -117,7 +116,6 @@ class Kind(IntEnum):
         return types_map[int(self)]
 
 
-@struct
 class LegacyUnion(Union):
     any: void_p
     latin1: ptr[c_uint8]  # Py_UCS1
@@ -125,7 +123,6 @@ class LegacyUnion(Union):
     ucs4: ptr[c_uint32]  # Py_UCS4
 
 
-@struct
 class PyASCIIObject(PyObject[str, None, None], IsGC):
     """
     Defines a PyUnicodeObject Structure
@@ -226,7 +223,6 @@ class PyASCIIObject(PyObject[str, None, None], IsGC):
         """Return the length of the string in code points."""
 
 
-@struct
 class PyCompactUnicodeObject(PyASCIIObject):
     """
     Defines a PyCompactUnicodeObject Structure
@@ -249,7 +245,6 @@ class PyCompactUnicodeObject(PyASCIIObject):
         }
 
 
-@struct
 class PyUnicodeObject(PyCompactUnicodeObject):
     """Defines a PyUnicodeObject Structure."""
 

--- a/src/einspect/types.py
+++ b/src/einspect/types.py
@@ -29,6 +29,9 @@ Resolves to the `_Ptr` class at runtime to allow for generic subscripting.
 Pointer = ctypes._Pointer
 """Alias to `ctypes._Pointer`."""
 
+PyCFuncPtrType = type(ctypes.PYFUNCTYPE(ctypes.c_void_p))
+"""Runtime Type of ``_ctypes.PyCFuncPtrType``."""
+
 _SelfPtr = object()
 """Singleton object returned on ptr[Self]."""
 

--- a/src/einspect/views/view_base.py
+++ b/src/einspect/views/view_base.py
@@ -234,6 +234,11 @@ class View(BaseView[_T, _KT, _VT]):
             )
         self._pyobject.instance_dict().contents = PyObject.from_object(value).with_ref()
 
+    @property
+    def address(self) -> int:
+        """Memory address of the object."""
+        return self._pyobject.address
+
     def is_gc(self) -> bool:
         """
         Returns True if the object implements the Garbage Collector protocol.

--- a/src/einspect/views/view_type.py
+++ b/src/einspect/views/view_type.py
@@ -9,11 +9,11 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, Type, TypeVar, Union, 
 from typing_extensions import Self
 
 from einspect._typing import is_union
+from einspect.api import address
 from einspect.compat import Version
 from einspect.errors import UnsafeError
 from einspect.structs import PyTypeObject
 from einspect.structs.include.object_h import TpFlags
-from einspect.structs.py_type import TypeNewWrapper
 from einspect.structs.slots_map import (
     Slot,
     get_slot,
@@ -22,7 +22,15 @@ from einspect.structs.slots_map import (
     tp_as_number,
     tp_as_sequence,
 )
-from einspect.type_orig import add_cache, get_cache, in_cache
+from einspect.type_orig import (
+    add_cache,
+    add_impls,
+    get_cache,
+    get_type_cache,
+    in_cache,
+    in_impls,
+    normalize_slot_attr,
+)
 from einspect.views.view_base import REF_DEFAULT, VarView
 
 if TYPE_CHECKING:
@@ -78,11 +86,8 @@ def _restore_impl(*types: type, name: str) -> None:
         # Get the original attribute from cache
         if in_cache(t, name):
             attr = get_cache(t, name)
-            # For TypeNewWrapper, use the original slot wrapper
-            if isinstance(t, TypeNewWrapper):
-                attr = t._orig_slot_fn
             # Set the attribute back using a view
-            v[name] = attr
+            v[name] = normalize_slot_attr(attr)
         else:
             # If there is no original attribute, delete the attribute
             with v.as_mutable():
@@ -234,7 +239,10 @@ class TypeView(VarView[_T, None, None]):
             return
         py_objs = [self._pyobject]
         if subclasses:
-            for sub in self._pyobject.GetAttr("__subclasses__")():
+            sub_fn = self._pyobject.GetAttr("__subclasses__")
+            # __subclasses__ takes 1 argument if we are `type`
+            args = (type,) if self.address == address(type) else ()
+            for sub in sub_fn(*args):
                 assert isinstance(sub, type)
                 py_objs.append(PyTypeObject.from_object(sub))
         for py_obj in py_objs:
@@ -258,23 +266,57 @@ class TypeView(VarView[_T, None, None]):
         for s in slots:
             self._try_alloc(s)
 
+    def restore(self, *names: str | Callable) -> None:
+        """
+        Restore named attribute(s) on type.
+
+        Args:
+            *names: Optional name(s) of attribute(s) to restore.
+                Can be str or callable with ``__name__``. If empty, restore all attributes.
+        """
+        type_ = self._pyobject.into_object()
+
+        if not names:
+            # Restore all attributes
+            type_cache = get_type_cache(type_)
+            for name, attr in type_cache.items():
+                self[name] = normalize_slot_attr(attr)
+            return type_
+
+        # Normalize names of stuff like properties and class methods
+        names = [get_func_name(n) if callable(n) else n for n in names]
+        # Check all names exist first
+        for name in names:
+            if in_cache(type_, name):
+                attr = get_cache(type_, name)
+                self[name] = normalize_slot_attr(attr)
+            # If in impl record, and not in cache, remove the attribute
+            elif in_impls(type_, name):
+                del self[name]
+            else:
+                raise AttributeError(
+                    f"{type_.__name__!r} has no original attribute {name!r}"
+                )
+
     def __getitem__(self, key: str) -> Any:
         """Get an attribute from the type object."""
         return self._pyobject.GetAttr(key)
 
-    def __setitem__(self, key: str | tuple[str, ...], value: Any) -> None:
+    def __setitem__(self, names: str | tuple[str, ...], value: Any) -> None:
         """
         Set attributes on the type object.
 
         Multiple string keys can be used to set multiple attributes to the same value.
         """
-        keys = (key,) if isinstance(key, str) else key
+        keys = (names,) if isinstance(names, str) else names
         # For all alloc mode, allocate now
         if self._alloc_mode == "all":
             self.alloc_slot()
         for name in keys:
-            # Cache original implementation
             base = self.base
+            # Add impls record
+            add_impls(base, name)
+            # Cache original implementation
             if not in_cache(base, name):
                 with suppress(AttributeError):
                     attr = getattr(base, name)
@@ -289,9 +331,21 @@ class TypeView(VarView[_T, None, None]):
             with self.as_mutable():
                 self._pyobject.setattr_safe(name, value)
 
-    # <-- Begin Managed::Properties (structs::py_type.PyTypeObject) -->
+    def __delitem__(self, names: str | tuple[str, ...]) -> None:
+        """Delete attributes from the type object."""
+        keys = (names,) if isinstance(names, str) else names
+        for name in keys:
+            base = self.base
+            # Add impls record
+            add_impls(base, name)
+            # Cache original implementation
+            if not in_cache(base, name):
+                with suppress(AttributeError):
+                    attr = getattr(base, name)
+                    add_cache(base, name, attr)
 
-    # <-- End Managed::Properties -->
+            with self.as_mutable():
+                self._pyobject.delattr_safe(name)
 
     def __getattr__(self, item: str):
         # Forward `tp_` attributes from PyTypeObject

--- a/src/einspect/views/view_type.py
+++ b/src/einspect/views/view_type.py
@@ -147,12 +147,13 @@ def impl(
 
     def wrapper(func: _Fn) -> _Fn:
         # detach requires weakrefs
-        try:
-            weakref.ref(get_func_base(func))
-        except TypeError:
-            raise TypeError(
-                f"detach=True requires function {func!r} to support weakrefs"
-            ) from None
+        if detach:
+            try:
+                weakref.ref(get_func_base(func))
+            except TypeError:
+                raise TypeError(
+                    f"detach=True requires function {func!r} to support weakrefs"
+                ) from None
 
         name = get_func_name(func)
 

--- a/src/einspect/views/view_type.py
+++ b/src/einspect/views/view_type.py
@@ -111,7 +111,7 @@ def _attach_finalizer(types: Sequence[type], func: Callable) -> None:
 
 
 def impl(
-    *cls: Type[_T] | UnionType,
+    *cls: Type[_T] | type | UnionType,
     alloc: AllocMode | None = None,
     detach: bool = False,
 ) -> Callable[[_Fn], _Fn]:

--- a/src/einspect/views/view_type.py
+++ b/src/einspect/views/view_type.py
@@ -238,7 +238,7 @@ class TypeView(VarView[_T, None, None]):
         if slot.ptr_type is None:
             return
         py_objs = [self._pyobject]
-        if subclasses:
+        if subclasses and self.base is not type:
             sub_fn = self._pyobject.GetAttr("__subclasses__")
             # __subclasses__ takes 1 argument if we are `type`
             args = (type,) if self.address == address(type) else ()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,16 +33,6 @@ class Unbuffered:
 
 def _run(func_path: Path, name: str):
     import importlib
-    from contextlib import suppress
-
-    # Optional subprocess coverage config
-    with suppress(ImportError):
-        import os
-
-        import coverage
-
-        os.putenv("COVERAGE_PROCESS_START", "1")
-        coverage.process_startup()
 
     rel_path = func_path.relative_to(TESTS_DIR)
     module_name = "tests." + ".".join(rel_path.with_suffix("").parts)

--- a/tests/structs/test_null.py
+++ b/tests/structs/test_null.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from einspect import NULL
-from einspect.structs import PyTupleObject, PyTypeObject
+from einspect.structs import MappingProxyObject, PyObject, PyTupleObject, PyTypeObject
 
 
 def test_func_ptr():
@@ -18,7 +18,7 @@ def test_func_ptr():
     assert n.nb_matrix_multiply == NULL
 
 
-def test_py_object():
+def test_py_object_arr():
     """Test usage as a NULL PyObject pointer."""
 
     s = PyTupleObject(
@@ -31,3 +31,28 @@ def test_py_object():
     assert not s.ob_item[1]
     assert s.ob_item[0] == NULL
     assert s.ob_item[1] == NULL
+
+    # Set an object value
+    s.ob_item[0] = PyObject(10).as_ref()
+    assert s.ob_item[0].contents.into_object() == 10
+
+    # Set back to NULL
+    s.ob_item[0] = NULL
+    assert not s.ob_item[0]
+
+
+def test_py_object():
+    """Test usage as a NULL PyObject pointer."""
+
+    class Foo:
+        x = 100
+
+    # Materialize dict
+    assert Foo.__dict__
+
+    s = PyTypeObject(Foo)
+    assert s.tp_dict != NULL
+
+    # Set to NULL
+    s.tp_dict = NULL
+    assert s.tp_dict == NULL

--- a/tests/structs/test_null.py
+++ b/tests/structs/test_null.py
@@ -1,0 +1,33 @@
+"""Test behavior of the `types.NULL` singleton."""
+from __future__ import annotations
+
+from einspect import NULL
+from einspect.structs import PyTupleObject, PyTypeObject
+
+
+def test_func_ptr():
+    """Test that NULL can be used as a function pointer."""
+
+    t = PyTypeObject(int)
+    n = t.tp_as_number.contents
+    assert n.nb_add != NULL
+    # Null FuncPtr should equal NULL
+    assert n.nb_matrix_multiply == NULL
+    # We can set this to NULL, and it'll invoke type(FuncPtr)()
+    n.nb_matrix_multiply = NULL
+    assert n.nb_matrix_multiply == NULL
+
+
+def test_py_object():
+    """Test usage as a NULL PyObject pointer."""
+
+    s = PyTupleObject(
+        ob_refcnt=1,
+        ob_type=PyTypeObject(tuple).as_ref(),
+        ob_size=2,
+        ob_item=[NULL] * 2,
+    )
+    assert not s.ob_item[0]
+    assert not s.ob_item[1]
+    assert s.ob_item[0] == NULL
+    assert s.ob_item[1] == NULL

--- a/tests/structs/test_structs.py
+++ b/tests/structs/test_structs.py
@@ -169,6 +169,15 @@ class TestPyTypeObject:
         assert repr_fn(50) == "50"
         assert repr_fn(True) == "1"
 
+    def test_setattr_safe_alloc_check(self):
+        # If PyMethods is NULL, should TypeError
+        py_int = st.PyTypeObject.from_object(int)
+        # PySequenceMethods pointer should be NULL for int
+        assert not py_int.tp_as_sequence
+
+        with pytest.raises(TypeError):
+            py_int.setattr_safe("__contains__", lambda a, b: True)
+
 
 class TestPyLongObject:
     def test_digit(self, new_int):

--- a/tests/test_impl.py
+++ b/tests/test_impl.py
@@ -158,3 +158,13 @@ def test_impl_detach_weakref():
     # With detach=False, it should work
     res = impl(SomeClass, detach=False)(fn)
     assert res is fn
+
+
+def test_impl_type():
+    # Test that impl works on types
+    @impl(type, detach=True)
+    def __matmul__(self, other):
+        return self, other
+
+    # noinspection PyUnresolvedReferences
+    assert str @ 123 == (str, 123)

--- a/tests/test_impl.py
+++ b/tests/test_impl.py
@@ -139,9 +139,22 @@ def test_impl_new():
 
 def test_impl_detach_weakref():
     # impl detach should require methods to be weakrefable
-    class Foo:
+    class SomeClass:
         pass
+
+    class Func:
+        __slots__ = ("_func",)
+        __name__ = "Func"
+
+        def __call__(self, *args, **kwargs):
+            pass
+
+    fn = Func()
 
     with pytest.raises(TypeError, match="support weakrefs"):
         # noinspection PyTypeChecker
-        impl(Foo, detach=True)(123)
+        impl(SomeClass, detach=True)(fn)
+
+    # With detach=False, it should work
+    res = impl(SomeClass, detach=False)(fn)
+    assert res is fn

--- a/tests/test_impl.py
+++ b/tests/test_impl.py
@@ -8,6 +8,14 @@ import pytest
 from einspect import impl, orig, view
 
 
+def test_impl_error():
+    with pytest.raises(TypeError, match="cls must be a type"):
+        # noinspection PyTypeChecker
+        @impl(1)
+        def _foo_fn(self):
+            pass
+
+
 def test_impl_new_func():
     with ExitStack() as stack:
 
@@ -21,73 +29,16 @@ def test_impl_new_func():
         assert (10)._foo_fn(5) == "15"
 
 
-@pytest.mark.run_in_subprocess
-def test_impl_new_func_finalize():
-    # Test that finalizer works, deleting function should remove the impl
-    with ExitStack() as stack:
-
-        @impl(int, detach=True)
-        def _test_final(self):
-            return str(self)
-
-        stack.callback(_test_final._impl_finalize)
-
-        _test_final._impl_finalize()
-
-        with pytest.raises(AttributeError, match="has no attribute '_test_final'"):
-            # noinspection PyUnresolvedReferences
-            _ = (10)._test_final()
-
-
-@pytest.mark.run_in_subprocess
-def test_impl_cache():
-    # Test that impls are cached
-    @impl(int)
-    def _foo_fn(self, x: int) -> str:
-        return str(self + x)
-
-    impl(int)(_foo_fn)
-
-    # noinspection PyUnresolvedReferences
-    assert (10)._foo_fn(5) == "15"
-
-    # Restore original
-    view(int).restore("_foo_fn")
-
-
 def test_impl_new_property():
     UserStr = type("UserStr", (str,), {})
 
     @impl(UserStr, detach=True)
     @property
-    def _custom_as_str(self) -> str:
-        return orig(UserStr).__str__(self)
+    def as_str(self) -> str:
+        return str(self)
 
     # noinspection PyUnresolvedReferences
-    assert UserStr("abc")._custom_as_str == "abc"
-
-
-# noinspection PyUnresolvedReferences
-@pytest.mark.run_in_subprocess
-def test_impl_new_slot():
-    UserType = type("UserType", (object,), {})
-    obj = UserType()
-
-    @impl(UserType)
-    def __getitem__(self, item) -> str:
-        return item
-
-    assert obj[0] == 0
-    assert obj[1] == 1
-
-
-@pytest.mark.run_in_subprocess
-def test_impl_error():
-    with pytest.raises(TypeError, match="cls must be a type"):
-        # noinspection PyTypeChecker
-        @impl(1)
-        def _foo_fn(self):
-            pass
+    assert UserStr("abc").as_str == "abc"
 
 
 def test_impl_func():
@@ -96,12 +47,21 @@ def test_impl_func():
     def __matmul__(self, other):
         return self * other
 
+    assert hasattr(int, "__matmul__")
+
     a = 4
     b = 10
     # noinspection PyUnresolvedReferences
     assert a @ b == 40
 
+    # Restore original (this deletes our implementation)
     view(int).restore("__matmul__")
+    # check int no longer has __matmul__
+    assert not hasattr(int, "__matmul__")
+    # using the operator should error
+    with pytest.raises(TypeError):
+        # noinspection PyUnresolvedReferences
+        assert not a @ b
 
 
 def test_impl_property():
@@ -114,76 +74,14 @@ def test_impl_property():
         _call = self
         return orig(int).real.__get__(self)
 
+    assert int.real is real
+
     assert (123).real == 123
     assert _call == 123
 
     assert (456).real == 456
     assert _call == 456
 
-
-def test_impl_new():
-    _call = None
-
-    @impl(object, detach=True)
-    def __new__(cls, *args, **kwargs):
-        nonlocal _call
-        _call = (cls, args, kwargs)
-        return orig(cls).__new__(cls, *args, **kwargs)
-
-    # Test normal object creation
-    _ = object()
-    assert _call == (object, (), {})
-
-    # Test subclass
-    class Foo:
-        def __init__(self, a, b, kwd=None):
-            self.args = (a, b)
-            self.kwd = kwd
-
-    obj = Foo(1, 2, kwd="hi")
-    assert isinstance(obj, Foo)
-    assert _call == (Foo, (1, 2), {"kwd": "hi"})
-
-
-@pytest.mark.run_in_subprocess
-def test_impl_detach_weakref():
-    # impl detach should require methods to be weakrefable
-    class SomeClass:
-        pass
-
-    class Func:
-        __slots__ = ("_func",)
-        __name__ = "Func"
-
-        def __call__(self, *args, **kwargs):
-            pass
-
-    fn = Func()
-
-    with pytest.raises(TypeError, match="support weakrefs"):
-        # noinspection PyTypeChecker
-        impl(SomeClass, detach=True)(fn)
-
-    # With detach=False, it should work
-    res = impl(SomeClass, detach=False)(fn)
-    assert res is fn
-
-
-@pytest.mark.run_in_subprocess
-def test_impl_type():
-    # Test that impl works on types
-    @impl(type)
-    def __matmul__(self, other):
-        return self, other
-
-    # stack.callback(__matmul__._impl_finalize)
-
-    # noinspection PyUnresolvedReferences
-    assert str @ 123 == (str, 123)
-
-    # Should also work for custom types
-    class Foo:
-        pass
-
-    # noinspection PyUnresolvedReferences
-    assert Foo @ "hi" == (Foo, "hi")
+    # Restore original
+    view(int).restore("real")
+    assert int.real is not real

--- a/tests/test_impl_sp.py
+++ b/tests/test_impl_sp.py
@@ -1,0 +1,121 @@
+"""(Subprocess) Tests for the @impl decorator and orig proxy."""
+from __future__ import annotations
+
+import pytest
+
+from einspect import impl, orig, view
+
+
+@pytest.mark.run_in_subprocess
+def test_impl_new_func_finalize():
+    # Test that finalizer works, deleting function should remove the impl
+    @impl(int, detach=True)
+    def _test_final(self):
+        return str(self)
+
+    _test_final._impl_finalize()
+
+    with pytest.raises(AttributeError, match="has no attribute '_test_final'"):
+        # noinspection PyUnresolvedReferences
+        _ = (10)._test_final()
+
+    assert not hasattr(int, "_test_final")
+
+
+@pytest.mark.run_in_subprocess
+def test_impl_cache():
+    # Test that impls are cached
+    @impl(int)
+    def _foo_fn(self, x: int) -> str:
+        return str(self + x)
+
+    impl(int)(_foo_fn)
+
+    # noinspection PyUnresolvedReferences
+    assert (10)._foo_fn(5) == "15"
+
+    # Restore original
+    view(int).restore("_foo_fn")
+
+
+# noinspection PyUnresolvedReferences
+@pytest.mark.run_in_subprocess
+def test_impl_new_slot():
+    UserType = type("UserType", (object,), {})
+    obj = UserType()
+
+    @impl(UserType)
+    def __getitem__(self, item) -> str:
+        return item
+
+    assert obj[0] == 0
+    assert obj[1] == 1
+
+
+@pytest.mark.run_in_subprocess
+def test_impl_detach_weakref():
+    # impl detach should require methods to be weakrefable
+    class SomeClass:
+        pass
+
+    class Func:
+        __slots__ = ("_func",)
+        __name__ = "Func"
+
+        def __call__(self, *args, **kwargs):
+            pass
+
+    fn = Func()
+
+    with pytest.raises(TypeError, match="support weakrefs"):
+        # noinspection PyTypeChecker
+        impl(SomeClass, detach=True)(fn)
+
+    # With detach=False, it should work
+    res = impl(SomeClass, detach=False)(fn)
+    assert res is fn
+
+
+@pytest.mark.run_in_subprocess
+def test_impl_type():
+    # Test that impl works on types
+    @impl(type)
+    def __matmul__(self, other):
+        return self, other
+
+    # stack.callback(__matmul__._impl_finalize)
+
+    # noinspection PyUnresolvedReferences
+    assert str @ 123 == (str, 123)
+
+    # Should also work for custom types
+    class Foo:
+        pass
+
+    # noinspection PyUnresolvedReferences
+    assert Foo @ "hi" == (Foo, "hi")
+
+
+@pytest.mark.run_in_subprocess
+def test_impl_new():
+    _call = None
+
+    @impl(object, detach=True)
+    def __new__(cls, *args, **kwargs):
+        nonlocal _call
+        _call = (cls, args, kwargs)
+        return orig(cls).__new__(cls, *args, **kwargs)
+
+    # Test normal object creation
+    _ = object()
+    assert _call == (object, (), {})
+
+    # Test subclass
+    class Foo:
+        def __init__(self, a, b, kwd=None):
+            self.args = (a, b)
+            self.kwd = kwd
+
+    obj = Foo(1, 2, kwd="hi")
+    assert isinstance(obj, Foo)
+    assert _call == (Foo, (1, 2), {"kwd": "hi"})

--- a/tests/test_orig.py
+++ b/tests/test_orig.py
@@ -1,4 +1,13 @@
-from einspect.type_orig import _cache, get_cache, in_cache, orig
+import pytest
+
+from einspect.type_orig import (
+    _cache,
+    get_cache,
+    get_type_cache,
+    in_cache,
+    orig,
+    try_cache_attr,
+)
 
 
 def test_orig() -> None:
@@ -20,3 +29,18 @@ def test_orig_cache() -> None:
     assert get_cache(str, "upper") == str.upper
     # check in orig
     assert orig(str).upper("abc") == "ABC"
+
+
+def test_get_type_cache() -> None:
+    class A:
+        pass
+
+    # Initially should not be in cache
+    with pytest.raises(KeyError):
+        get_type_cache(A)
+
+    # Add to cache
+    A.abc = 123
+    try_cache_attr(A, "abc")
+
+    assert get_type_cache(A) == {"abc": 123}

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -5,7 +5,7 @@ from einspect._patch import _Null_LP_PyObject
 
 def test_null_lp_repr() -> None:
     obj = _Null_LP_PyObject()
-    assert repr(obj).startswith("<NULL ptr[PyObject] at")
+    assert repr(obj).startswith("<Null LP_PyObject at")
 
 
 def test_null_lp_eq() -> None:

--- a/tests/views/test_move.py
+++ b/tests/views/test_move.py
@@ -7,26 +7,31 @@ from einspect import view
 from einspect.errors import UnsafeError
 
 
-def test_move_err(new_int: int):
-    v = view(new_int)
+def test_move_err():
+    v = view(123)
     with pytest.raises(TypeError), v.unsafe():
         v.move_to("not a view")  # type: ignore
 
 
-def test_move_op(new_int: int):
-    v = view(new_int)
-    v <<= 5
-    assert new_int == 5
-    assert id(new_int) != id(5)
+@pytest.mark.run_in_subprocess
+def test_move_op():
+    a = literal_eval("'eed25194-bb5e-4c96'")
+    b = literal_eval("'90d584f0-2b6e-449c'")
+    v = view(a)
+    v <<= b
+    assert a == b
 
 
-def test_move_from(new_int: int):
-    v = view(new_int)
-    v.move_from(view(5))
-    assert new_int == 5
-    assert id(new_int) != id(5)
+@pytest.mark.run_in_subprocess
+def test_move_from():
+    a = literal_eval("'1121e2bf-2078-427f'")
+    b = literal_eval("'704ffc52-f6dd-4ed6'")
+    v = view(a)
+    v.move_from(view(b))
+    assert a == b
 
 
+@pytest.mark.run_in_subprocess
 def test_move_instance_dicts():
     """Move between objects with instance dicts."""
     Foo = type("Num", (tuple,), {})
@@ -40,6 +45,7 @@ def test_move_instance_dicts():
     assert x.__dict__ is y.__dict__
 
 
+@pytest.mark.run_in_subprocess
 def test_move_str():
     """Move between strs."""
     a = literal_eval("'abcdef'")
@@ -60,7 +66,7 @@ def test_move_unsafe_size():
 
 def test_move_unsafe_gc_types():
     """Unsafe move due to non-gc type into gc type."""
-    ls = [1, 2, 3]
+    ls = ["f6dd", "4ed6"]
     v = view(ls)
     with pytest.raises(UnsafeError, match="gc type"):
         v <<= 10
@@ -77,6 +83,7 @@ def test_move_unsafe_instance_dict():
         v <<= Num()
 
 
+@pytest.mark.run_in_subprocess
 def test_swap():
     a = literal_eval("'78950fa2-93a4-4ac4'")
     b = literal_eval("'236ad434-c134-4f75'")
@@ -86,6 +93,7 @@ def test_swap():
     assert b == "78950fa2-93a4-4ac4"
 
 
+@pytest.mark.run_in_subprocess
 def test_swap_dict():
     # Classes with instance dicts should also be swapped
     A = type("A", (int,), {})

--- a/tests/views/test_view_base.py
+++ b/tests/views/test_view_base.py
@@ -75,6 +75,12 @@ class TestView:
         v = view(obj)  # type: ignore
         assert type(v) is self.view_type
 
+    def test_address(self):
+        obj = self.get_obj()
+        v = self.view_type(obj)
+        assert v.address == v._pyobject.address
+        assert v.address == id(obj)
+
     def test_size(self):
         # For sized test subclasses
         obj = self.get_obj()


### PR DESCRIPTION
## Added:
- `View.address` property that returns the memory address of an object, like `PyObject.address`
- `TypeView.restore` restores the previously set or deleted attribute on a type
- `TypeView.__delitem__` type view subscripting now supports deletion:
```python
del view(int)["__pow__"]

print(2 ** 85)
# TypeError: unsupported operand type(s) for ** or pow(): 'int' and 'int'
```

## Enhancements:
- Added `Struct` base metaclass form of `@struct` decorator, simplify internal usages in `PyObject` and other structures.

## Fixes:
- Skip weakref check when detach=False