### PR TITLE
Enhance stability of `impl` and `TypeView` setitem, fix Struct cast for PyCFunction types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,12 +22,12 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.0.245"
     hooks:
-      - id: flake8
-        additional_dependencies: [flake8-builtins, flake8-print]
+      - id: ruff
         files: ^src/
         args:
-          - --ignore=W503,E203,F842,A003,F403,F405
-          - --max-line-length=120
+          - --ignore=F842,A003,F403,F405
+          - --line-length=120
+          - --fix

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
 project = "einspect"
 copyright = "2023, Ionite"
 author = "Ionite"
-release = "v0.5.11"
+release = "v0.5.12"
 
 
 # -- General configuration ---------------------------------------------------

--- a/poetry.lock
+++ b/poetry.lock
@@ -616,6 +616,7 @@ files = [
     {file = "debugpy-1.6.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b5d1b13d7c7bf5d7cf700e33c0b8ddb7baf030fcf502f76fc061ddd9405d16c"},
     {file = "debugpy-1.6.6-cp38-cp38-win32.whl", hash = "sha256:70ab53918fd907a3ade01909b3ed783287ede362c80c75f41e79596d5ccacd32"},
     {file = "debugpy-1.6.6-cp38-cp38-win_amd64.whl", hash = "sha256:c05349890804d846eca32ce0623ab66c06f8800db881af7a876dc073ac1c2225"},
+    {file = "debugpy-1.6.6-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:11a0f3a106f69901e4a9a5683ce943a7a5605696024134b522aa1bfda25b5fec"},
     {file = "debugpy-1.6.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a771739902b1ae22a120dbbb6bd91b2cae6696c0e318b5007c5348519a4211c6"},
     {file = "debugpy-1.6.6-cp39-cp39-win32.whl", hash = "sha256:549ae0cb2d34fc09d1675f9b01942499751d174381b6082279cf19cdb3c47cbe"},
     {file = "debugpy-1.6.6-cp39-cp39-win_amd64.whl", hash = "sha256:de4a045fbf388e120bb6ec66501458d3134f4729faed26ff95de52a754abddb1"},
@@ -748,39 +749,6 @@ docs = ["furo (>=2022.12.7)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.1
 testing = ["covdefaults (>=2.2.2)", "coverage (>=7.0.1)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-timeout (>=2.1)"]
 
 [[package]]
-name = "flake8"
-version = "6.0.0"
-description = "the modular source code checker: pep8 pyflakes and co"
-category = "dev"
-optional = false
-python-versions = ">=3.8.1"
-files = [
-    {file = "flake8-6.0.0-py2.py3-none-any.whl", hash = "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7"},
-    {file = "flake8-6.0.0.tar.gz", hash = "sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181"},
-]
-
-[package.dependencies]
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.10.0,<2.11.0"
-pyflakes = ">=3.0.0,<3.1.0"
-
-[[package]]
-name = "flake8-print"
-version = "5.0.0"
-description = "print statement checker plugin for flake8"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "flake8-print-5.0.0.tar.gz", hash = "sha256:76915a2a389cc1c0879636c219eb909c38501d3a43cc8dae542081c9ba48bdf9"},
-    {file = "flake8_print-5.0.0-py3-none-any.whl", hash = "sha256:84a1a6ea10d7056b804221ac5e62b1cee1aefc897ce16f2e5c42d3046068f5d8"},
-]
-
-[package.dependencies]
-flake8 = ">=3.0"
-pycodestyle = "*"
-
-[[package]]
 name = "fqdn"
 version = "1.5.1"
 description = "Validates fully-qualified domain names against RFC 1123, so that they are acceptable to modern bowsers"
@@ -871,14 +839,14 @@ testing = ["flake8 (<5)", "flufl.flake8", "importlib-resources (>=1.3)", "packag
 
 [[package]]
 name = "importlib-resources"
-version = "5.10.2"
+version = "5.12.0"
 description = "Read resources from Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "importlib_resources-5.10.2-py3-none-any.whl", hash = "sha256:7d543798b0beca10b6a01ac7cafda9f822c54db9e8376a6bf57e0cbd74d486b6"},
-    {file = "importlib_resources-5.10.2.tar.gz", hash = "sha256:e4a96c8cc0339647ff9a5e0550d9f276fc5a01ffa276012b58ec108cfd7b8484"},
+    {file = "importlib_resources-5.12.0-py3-none-any.whl", hash = "sha256:7b1deeebbf351c7578e09bf2f63fa2ce8b5ffec296e0d349139d43cca061a81a"},
+    {file = "importlib_resources-5.12.0.tar.gz", hash = "sha256:4be82589bf5c1d7999aedf2a45159d10cb3ca4f19b2271f8792bc8e6da7b22f6"},
 ]
 
 [package.dependencies]
@@ -1125,14 +1093,14 @@ qtconsole = "*"
 
 [[package]]
 name = "jupyter-client"
-version = "8.0.2"
+version = "8.0.3"
 description = "Jupyter protocol implementation and client libraries"
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jupyter_client-8.0.2-py3-none-any.whl", hash = "sha256:c53731eb590b68839b0ce04bf46ff8c4f03278f5d9fe5c3b0f268a57cc2bd97e"},
-    {file = "jupyter_client-8.0.2.tar.gz", hash = "sha256:47ac9f586dbcff4d79387ec264faf0fdeb5f14845fa7345fd7d1e378f8096011"},
+    {file = "jupyter_client-8.0.3-py3-none-any.whl", hash = "sha256:be48ac6bd659cbbddb7a674cf06b3b8afbf53f228253cf58bde604c03bd487b0"},
+    {file = "jupyter_client-8.0.3.tar.gz", hash = "sha256:ed65498bea6d876ef9d8da3e0db3dd33c5d129f5b2645f56ae03993782966bd0"},
 ]
 
 [package.dependencies]
@@ -1220,14 +1188,14 @@ test = ["click", "coverage", "pre-commit", "pytest (>=7.0)", "pytest-asyncio (>=
 
 [[package]]
 name = "jupyter-server"
-version = "2.2.1"
+version = "2.3.0"
 description = "The backend—i.e. core services, APIs, and REST endpoints—to Jupyter web applications."
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jupyter_server-2.2.1-py3-none-any.whl", hash = "sha256:854fb7d49f6b7f545d4f8354172b004dcda887ba0699def7112daf785ba3c9ce"},
-    {file = "jupyter_server-2.2.1.tar.gz", hash = "sha256:5afb8a0cdfee37d02d69bdf470ae9cbb1dee5d4788f9bc6cc8e54bd8c83fb096"},
+    {file = "jupyter_server-2.3.0-py3-none-any.whl", hash = "sha256:b15078954120886d580e19d1746e2b62a3dc7bd082cb4716115c25fcd7061b00"},
+    {file = "jupyter_server-2.3.0.tar.gz", hash = "sha256:29d6657bfb160b0e39b9030d67f33f918a188f2eba28065314a933b327fef872"},
 ]
 
 [package.dependencies]
@@ -1399,27 +1367,15 @@ files = [
 traitlets = "*"
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
-]
-
-[[package]]
 name = "mdit-py-plugins"
-version = "0.3.3"
+version = "0.3.4"
 description = "Collection of plugins for markdown-it-py"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "mdit-py-plugins-0.3.3.tar.gz", hash = "sha256:5cfd7e7ac582a594e23ba6546a2f406e94e42eb33ae596d0734781261c251260"},
-    {file = "mdit_py_plugins-0.3.3-py3-none-any.whl", hash = "sha256:36d08a29def19ec43acdcd8ba471d3ebab132e7879d442760d963f19913e04b9"},
+    {file = "mdit-py-plugins-0.3.4.tar.gz", hash = "sha256:3278aab2e2b692539082f05e1243f24742194ffd92481f48844f057b51971283"},
+    {file = "mdit_py_plugins-0.3.4-py3-none-any.whl", hash = "sha256:4f1441264ac5cb39fa40a5901921c2acf314ea098d75629750c138f80d552cdf"},
 ]
 
 [package.dependencies]
@@ -1546,14 +1502,14 @@ testing = ["beautifulsoup4", "coverage[toml]", "pytest (>=6,<7)", "pytest-cov", 
 
 [[package]]
 name = "nbclassic"
-version = "0.5.1"
+version = "0.5.2"
 description = "Jupyter Notebook as a Jupyter Server extension."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "nbclassic-0.5.1-py3-none-any.whl", hash = "sha256:32c235e1f22f4048f3b877d354c198202898797cf9c2085856827598cead001b"},
-    {file = "nbclassic-0.5.1.tar.gz", hash = "sha256:8e8ffce7582bb7a4baf11fa86a3d88b184e8e7df78eed4ead69f15aa4fc0e323"},
+    {file = "nbclassic-0.5.2-py3-none-any.whl", hash = "sha256:6403a996562dadefa7fee9c49e17b663b5fd508241de5df655b90011cf3342d9"},
+    {file = "nbclassic-0.5.2.tar.gz", hash = "sha256:40f11bbcc59e8956c3d5ef132dec8e5a853e893ecf831e791d54da0d8a50d79d"},
 ]
 
 [package.dependencies]
@@ -1563,7 +1519,7 @@ ipython-genutils = "*"
 jinja2 = "*"
 jupyter-client = ">=6.1.1"
 jupyter-core = ">=4.6.1"
-jupyter-server = ">=1.17.0"
+jupyter-server = ">=1.8"
 nbconvert = ">=5"
 nbformat = "*"
 nest-asyncio = ">=1.5"
@@ -1971,18 +1927,6 @@ files = [
 tests = ["pytest"]
 
 [[package]]
-name = "pycodestyle"
-version = "2.10.0"
-description = "Python style guide checker"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "pycodestyle-2.10.0-py2.py3-none-any.whl", hash = "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610"},
-    {file = "pycodestyle-2.10.0.tar.gz", hash = "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053"},
-]
-
-[[package]]
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
@@ -1992,18 +1936,6 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
-]
-
-[[package]]
-name = "pyflakes"
-version = "3.0.1"
-description = "passive checker of Python programs"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "pyflakes-3.0.1-py2.py3-none-any.whl", hash = "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf"},
-    {file = "pyflakes-3.0.1.tar.gz", hash = "sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd"},
 ]
 
 [[package]]
@@ -2455,6 +2387,33 @@ typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9
 jupyter = ["ipywidgets (>=7.5.1,<8.0.0)"]
 
 [[package]]
+name = "ruff"
+version = "0.0.247"
+description = "An extremely fast Python linter, written in Rust."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.0.247-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:0151face9ef0e09c0d09166eae5f6df9d61ed7b1686086092d56164b790d1adf"},
+    {file = "ruff-0.0.247-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:0abffda0039dc0eec18d624a48a725c414587c816194d1c9889eceba82e87ad0"},
+    {file = "ruff-0.0.247-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e34ce0a12a9c7ac25fcfd8a9a25ade778f4e54df37f7ce58c406c36f9d5a1e3"},
+    {file = "ruff-0.0.247-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c31adc9f08e1652acb6c1b6d494a3e52895e341398b5dcaffe3325688f70de87"},
+    {file = "ruff-0.0.247-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ebc3b3077a880ea8af9f17c5614f606d6c1a15db6823501f4b8d3daf51f78782"},
+    {file = "ruff-0.0.247-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:403f67452655923d0775c6c3854750e77c9c97eb875ea979ad515d3c75a45cff"},
+    {file = "ruff-0.0.247-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53dd6124c6b822c27ee23965ce9d8c5fbc76a97ecc209daef0bbfbe8f905cb18"},
+    {file = "ruff-0.0.247-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f1483c7435db4926da3793a89f6bbb68dedf2990aeddef01407d8c47953403e0"},
+    {file = "ruff-0.0.247-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ce619be01206ab71054c9f492a803cc81be678222379c69a0d60aa66c30e4a2"},
+    {file = "ruff-0.0.247-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:172c0a8fb295259d9e12e43c39cf3bd006ae85eae89b8e9ca6ece7252241b603"},
+    {file = "ruff-0.0.247-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:0cda3a13e67adaf5198c69847a2f04011434bdfbfdca05ac32c101991dd56162"},
+    {file = "ruff-0.0.247-py3-none-musllinux_1_2_i686.whl", hash = "sha256:4481b5b6103dffc09156f2fea79a9a9282a72c0109ca4ab74828ae1089ec8c7e"},
+    {file = "ruff-0.0.247-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8c835b703cebb0f23d59ec3d83ff498c5290fae51f98df548aacbb9ff85cc93c"},
+    {file = "ruff-0.0.247-py3-none-win32.whl", hash = "sha256:3695f5fd2f4ad44030799a6021b2626442e8d92e432d646aadeefd4a1fceab12"},
+    {file = "ruff-0.0.247-py3-none-win_amd64.whl", hash = "sha256:3e22f08bc403d3b4f32488ea52cd69fc3cb343b2c99431fd969cda1c83f4bc2f"},
+    {file = "ruff-0.0.247-py3-none-win_arm64.whl", hash = "sha256:737b7fd25d2523b7c526830a3670364a953cb6c6bbf9912c78cba06bbf0ca125"},
+    {file = "ruff-0.0.247.tar.gz", hash = "sha256:cce9566cea1cb348bb2dec99f810d846d112627fa52bf3a554773ce4737a061b"},
+]
+
+[[package]]
 name = "send2trash"
 version = "1.8.0"
 description = "Send file to trash natively under Mac OS X, Windows and Linux."
@@ -2473,14 +2432,14 @@ win32 = ["pywin32"]
 
 [[package]]
 name = "setuptools"
-version = "67.3.1"
+version = "67.3.2"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.3.1-py3-none-any.whl", hash = "sha256:23c86b4e44432bfd8899384afc08872ec166a24f48a3f99f293b0a557e6a6b5d"},
-    {file = "setuptools-67.3.1.tar.gz", hash = "sha256:daec07fd848d80676694d6bf69c009d28910aeece68a38dbe88b7e1bb6dba12e"},
+    {file = "setuptools-67.3.2-py3-none-any.whl", hash = "sha256:bb6d8e508de562768f2027902929f8523932fcd1fb784e6d573d2cafac995a48"},
+    {file = "setuptools-67.3.2.tar.gz", hash = "sha256:95f00380ef2ffa41d9bba85d95b27689d923c93dfbafed4aecd7cf988a25e012"},
 ]
 
 [package.extras]
@@ -2965,14 +2924,14 @@ files = [
 
 [[package]]
 name = "zipp"
-version = "3.13.0"
+version = "3.14.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "zipp-3.13.0-py3-none-any.whl", hash = "sha256:e8b2a36ea17df80ffe9e2c4fda3f693c3dad6df1697d3cd3af232db680950b0b"},
-    {file = "zipp-3.13.0.tar.gz", hash = "sha256:23f70e964bc11a34cef175bc90ba2914e1e4545ea1e3e2f67c079671883f9cb6"},
+    {file = "zipp-3.14.0-py3-none-any.whl", hash = "sha256:188834565033387710d046e3fe96acfc9b5e86cbca7f39ff69cf21a4128198b7"},
+    {file = "zipp-3.14.0.tar.gz", hash = "sha256:9e5421e176ef5ab4c0ad896624e87a7b2f07aca746c9b2aa305952800cb8eecb"},
 ]
 
 [package.extras]
@@ -2982,4 +2941,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.13"
-content-hash = "409dcbca83a6959575a41448d52de0c92e1f74209cca72c9f8a6049e1faf0e50"
+content-hash = "132b65b1b73421230b05104f24277aeee04a17be0214b89c72fd0d8804a26e4f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "einspect"
-version = "0.5.11"
+version = "0.5.12"
 packages = [{ include = "einspect", from = "src" }]
 description = "Extended Inspect - view and modify memory structs of runtime objects."
 authors = ["ionite34 <dev@ionite.io>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,8 @@ pytest-cov = "^4.0.0"
 pytest-xdist = "^3.1.0"
 mypy = "^0.991"
 pre-commit = "^2.20.0"
-flake8 = { version = "^6.0.0", python = ">= 3.8.1" }
-flake8-print = { version = "^5.0.0", python = ">= 3.8.1" }
 black = "^23.1.0"
+ruff = "^0.0.247"
 
 [tool.poetry.group.tools.dependencies]
 rich = "^12.6.0"
@@ -72,6 +71,11 @@ myst-parser = "^0.18.1"
 sphinx-copybutton = "^0.5.1"
 furo = "^2022.12.7"
 sphinx-autodoc-typehints = "^1.21.8"
+
+[tool.ruff]
+ignore = ["F842", "A003", "F403", "F405"]
+line-length = 120
+fixable = ["F"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/src/einspect/__init__.py
+++ b/src/einspect/__init__.py
@@ -12,6 +12,6 @@ einspect._patch.run()
 
 __all__ = ("view", "unsafe", "impl", "orig", "ptr", "NULL")
 
-__version__ = "0.5.11"
+__version__ = "0.5.12"
 
 unsafe = global_unsafe

--- a/src/einspect/_typing.py
+++ b/src/einspect/_typing.py
@@ -8,4 +8,4 @@ def is_union(obj: Any) -> bool:
         return False
     if getattr(types, "UnionType", None):
         return get_origin(obj) in (Union, types.UnionType)
-    return get_origin(obj) is Union
+    return get_origin(obj) is Union  # pragma: no cover

--- a/src/einspect/structs/deco.py
+++ b/src/einspect/structs/deco.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import ctypes
 import logging
+import typing
 from ctypes import POINTER, Structure
 from functools import cached_property, partial
-from typing import Callable, Literal, Sequence, Tuple, Type, TypeVar, Union, overload
+from typing import Callable, Literal, Sequence, Tuple, Type, TypeVar, overload
 
 import typing_extensions
 from typing_extensions import get_args, get_type_hints
@@ -22,7 +23,7 @@ log = logging.getLogger(__name__)
 
 _T = TypeVar("_T", bound=Type[Structure])
 
-FieldsType = Sequence[Union[Tuple[str, type], Tuple[str, type, int]]]
+FieldsType = Sequence[typing.Union[Tuple[str, type], Tuple[str, type, int]]]
 
 
 @overload

--- a/src/einspect/structs/deco.py
+++ b/src/einspect/structs/deco.py
@@ -10,7 +10,11 @@ from typing import Callable, Literal, Sequence, Tuple, Type, TypeVar, overload
 import typing_extensions
 from typing_extensions import get_args, get_type_hints
 
-from einspect.protocols.type_parse import convert_type_hints, fix_ctypes_generics
+from einspect.protocols.type_parse import (
+    convert_type_hints,
+    fix_ctypes_generics,
+    is_ctypes_type,
+)
 from einspect.structs.traits import AsRef, Display
 from einspect.types import NULL, Pointer, PyCFuncPtrType, _SelfPtr
 
@@ -118,14 +122,19 @@ def _cast_field(field_type, value):
             return field_type()
         # try to coerce Structure subclasses
         # i.e. LP_PyObject should accept LP_PyDictObject
-        if issubclass(field_type._type_, Structure) and issubclass(
+        elif issubclass(field_type._type_, Structure) and issubclass(
             value._type_, field_type._type_
         ):
             return ctypes.cast(value, field_type)
 
-    # PYFUNCTYPE, create a null type of itself
+    # PYFUNCTYPE
     if isinstance(field_type, PyCFuncPtrType):
-        return field_type()
+        # For null, return new empty function pointer
+        if value is NULL:
+            return field_type()
+        # For function, cast with PYFUNCTYPE
+        elif not is_ctypes_type(value):
+            return field_type(value)
 
     return value
 

--- a/src/einspect/structs/include/object_h.py
+++ b/src/einspect/structs/include/object_h.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from ctypes import PYFUNCTYPE, c_char_p, c_int, c_void_p, py_object
-from enum import IntEnum
+from enum import IntEnum, IntFlag
 
 from einspect.api import Py_ssize_t
 from einspect.structs.deco import Struct
@@ -99,7 +99,7 @@ class PySendResult(IntEnum):
     PYGEN_NEXT = 1
 
 
-class TpFlags(IntEnum):
+class TpFlags(IntFlag):
     """
     Type flags (tp_flags)
 

--- a/src/einspect/structs/py_object.py
+++ b/src/einspect/structs/py_object.py
@@ -76,7 +76,7 @@ class PyObject(Struct, AsRef, Generic[_T, _KT, _VT]):
     _fields_: List[Union[Tuple[str, type], Tuple[str, type, int]]]
 
     @overload
-    def __new__(cls, __obj: _T) -> PyObject[_T, _KT, _VT]:
+    def __new__(cls, __obj: _T | PyObject[_T, _KT, _VT]) -> PyObject[_T, _KT, _VT]:
         ...
 
     @overload
@@ -139,10 +139,10 @@ class PyObject(Struct, AsRef, Generic[_T, _KT, _VT]):
         """Return the address of the PyObject."""
         return ctypes.addressof(self)
 
-    def __eq__(self, other: Self) -> bool:
-        """Return True if the PyObject is equal in address to the other."""
+    def __eq__(self, other: Self | object) -> bool:
+        """Return True if equal in address to another PyObject or object."""
         if not isinstance(other, PyObject):
-            return NotImplemented
+            return self.address == address(other)
         return self.address == other.address
 
     def __repr__(self) -> str:

--- a/src/einspect/structs/py_type.py
+++ b/src/einspect/structs/py_type.py
@@ -8,7 +8,6 @@ from ctypes import (
     c_char_p,
     c_uint,
     c_ulong,
-    c_void_p,
     cast,
     pointer,
     py_object,
@@ -110,7 +109,7 @@ class PyTypeObject(PyVarObject[_T, None, None]):
     tp_bases: ptr[PyObject]
     tp_mro: ptr[PyObject]  # method resolution order
     tp_cache: ptr[PyObject]
-    tp_subclasses: c_void_p  # for static builtin types this is an index
+    tp_subclasses: ptr[PyObject]  # for static builtin types this is an index
     tp_weaklist: ptr[PyObject]
     tp_del: destructor
 

--- a/src/einspect/structs/py_type.py
+++ b/src/einspect/structs/py_type.py
@@ -230,6 +230,10 @@ class PyTypeObject(PyVarObject[_T, None, None]):
         """
         return bool(self.tp_flags & TpFlags.HAVE_GC)
 
+    @bind_api(pythonapi["PyType_Ready"])
+    def Ready(self) -> int:
+        """Finalize a type object."""
+
     @bind_api(pythonapi["PyType_Modified"])
     def Modified(self) -> None:
         """Mark the type as modified."""

--- a/src/einspect/views/view_type.py
+++ b/src/einspect/views/view_type.py
@@ -9,11 +9,9 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, Type, TypeVar, Union, 
 from typing_extensions import Self
 
 from einspect._typing import is_union
-from einspect.api import address
 from einspect.compat import Version
 from einspect.errors import UnsafeError
-from einspect.structs import PyTypeObject
-from einspect.structs.include.object_h import TpFlags
+from einspect.structs import PyDictObject, PyObject, PyTypeObject, TpFlags
 from einspect.structs.slots_map import (
     Slot,
     get_slot,
@@ -47,6 +45,7 @@ _Fn = TypeVar("_Fn", bound=Callable)
 
 AllocMode = Literal["mapping", "sequence", "all"]
 ALLOC_MODES = frozenset({"mapping", "sequence", "all"})
+PY_METHOD_STRUCTS = weakref.WeakKeyDictionary()
 
 
 def get_func_name(func: Callable) -> str:
@@ -110,6 +109,94 @@ def _attach_finalizer(types: Sequence[type], func: Callable) -> None:
         func._impl_types = list(types)
 
     func._impl_finalize = weakref.finalize(func, _restore_impl, *types, name=name)
+
+
+def _patch_object_base() -> None:
+    """
+    Adds a new PyTypeObject into base mro of `object`.
+
+    This allows for PyMethods allocations on `object` without
+    breaking CPython's assumption checks on `object` having
+    PyMethod pointers as NULL.
+
+    Reference logic for object patch by chilaxan in:
+      - https://github.com/chilaxan/fishhook/blob/master/fishhook/fishhook.py
+    """
+    obj = PyTypeObject.from_object(object)
+
+    # Skip if already patched
+    if obj.tp_base:
+        return
+
+    base = PyTypeObject(
+        ob_refcnt=1,
+        ob_type=PyTypeObject.from_object(type).as_ref(),
+        tp_name=b"base_object",
+        tp_basicsize=object.__basicsize__,
+        tp_flags=TpFlags.READY | TpFlags.IMMUTABLETYPE,
+        tp_dict=PyObject.from_object({}).with_ref().as_ref(),
+        tp_bases=PyObject.from_object(()).with_ref().as_ref(),
+    )
+
+    # Patch to object
+    obj.tp_base = base.as_ref()
+
+    # Patch type.__base__ to return None on object instead of base_object
+    orig_base = vars(type)["__base__"].__get__
+
+    @property
+    def __base__(self):
+        if self is object:
+            return None
+        return orig_base(self)
+
+    type_obj = PyTypeObject.from_object(type)
+    type_obj.tp_dict.contents.astype(PyDictObject).SetItem("__base__", __base__)
+    type_obj.Modified()
+
+
+def _allocate_methods(obj: PyTypeObject, *slots: Slot, subclasses: bool = True) -> None:
+    """
+    Allocate PyMethods structs on the type.
+
+    Args:
+        obj: The type to allocate the PyMethod struct on.
+        slots: The slots to allocate.
+        subclasses: If True, will allocate the PyMethod struct on subclasses as well.
+    """
+    # Skip if no slots or no PyMethods struct on any slot
+    if not slots or not any(slot.ptr_type for slot in slots):
+        return
+
+    # For object, need to run a patch for bases
+    if obj == object:
+        _patch_object_base()
+
+    py_obj = obj.into_object()
+
+    if obj.ob_type.contents != type:
+        raise TypeError(f"obj must be a type, not {obj.ob_type[0].into_object()!r}")
+
+    if subclasses and obj != type:
+        sub_fn = obj.ob_type.contents.GetAttr("__subclasses__")
+        for t in sub_fn(py_obj):
+            py_type = PyTypeObject.from_object(t)
+            if py_type.ob_type.contents != type:
+                continue
+            _allocate_methods(PyTypeObject.from_object(t), *slots)
+
+    for slot in slots:
+        # Skip if no PyMethods struct for slot
+        if not slot.ptr_type:
+            continue
+        # Allocate if the slot is null
+        if not (py_method := getattr(obj, slot.parts[0])):
+            new_struct = slot.ptr_type()
+            # Need to keep a reference to the PyMethod struct,
+            # so it doesn't get garbage collected.
+            # Here we append it to a WeakKeyDictionary
+            PY_METHOD_STRUCTS.setdefault(py_obj, []).append(new_struct)
+            py_method.contents = new_struct
 
 
 def impl(
@@ -234,28 +321,7 @@ class TypeView(VarView[_T, None, None]):
         yield self
         self._alloc_mode = orig
 
-    def _try_alloc(self, slot: Slot, subclasses: bool = True) -> None:
-        """Allocate a slot method struct if the pointer is NULL."""
-        # Check if there is a ptr class
-        if slot.ptr_type is None:
-            return
-        py_objs = [self._pyobject]
-        if subclasses and self.base is not type:
-            sub_fn = self._pyobject.GetAttr("__subclasses__")
-            # __subclasses__ takes 1 argument if we are `type`
-            args = (type,) if self.address == address(type) else ()
-            for sub in sub_fn(*args):
-                assert isinstance(sub, type)
-                py_objs.append(PyTypeObject.from_object(sub))
-        for py_obj in py_objs:
-            # Check if the slot is a null pointer
-            ptr = getattr(py_obj, slot.parts[0])
-            if not ptr:
-                # Make a new ptr type struct
-                new = slot.ptr_type()
-                ptr.contents = new
-
-    def alloc_slot(self, *slot: Slot) -> None:
+    def alloc_slot(self, *slot: Slot, subclasses: bool = True) -> None:
         """
         Allocate slot method structs. Defaults to all the following:
 
@@ -265,8 +331,7 @@ class TypeView(VarView[_T, None, None]):
         - tp_as_sequence (PySequenceMethods)
         """
         slots = slot or (tp_as_async, tp_as_number, tp_as_mapping, tp_as_sequence)
-        for s in slots:
-            self._try_alloc(s)
+        _allocate_methods(self._pyobject, *slots, subclasses=subclasses)
 
     def restore(self, *names: str | Callable) -> None:
         """
@@ -330,7 +395,7 @@ class TypeView(VarView[_T, None, None]):
                 slot := get_slot(name, prefer=self._alloc_mode)
             ):
                 # Allocate sub-struct if needed
-                self._try_alloc(slot)
+                self.alloc_slot(slot)
 
             with self.as_mutable():
                 self._pyobject.setattr_safe(name, value)

--- a/src/einspect/views/view_type.py
+++ b/src/einspect/views/view_type.py
@@ -138,6 +138,9 @@ def _patch_object_base() -> None:
         tp_bases=PyObject.from_object(()).with_ref().as_ref(),
     )
 
+    # Keep a reference to the base object
+    PY_METHOD_STRUCTS.setdefault(object, []).append(base)
+
     # Patch to object
     obj.tp_base = base.as_ref()
 
@@ -175,7 +178,9 @@ def _allocate_methods(obj: PyTypeObject, *slots: Slot, subclasses: bool = True) 
     py_obj = obj.into_object()
 
     if obj.ob_type.contents != type:
-        raise TypeError(f"obj must be a type, not {obj.ob_type[0].into_object()!r}")
+        raise TypeError(
+            f"During allocation for {obj.into_object()}: obj must be a type, not {obj.ob_type[0].into_object()!r}"
+        )
 
     if subclasses and obj != type:
         sub_fn = obj.ob_type.contents.GetAttr("__subclasses__")

--- a/src/einspect/views/view_type.py
+++ b/src/einspect/views/view_type.py
@@ -425,6 +425,8 @@ class TypeView(VarView[_T, None, None]):
         raise AttributeError(item)
 
     def __setattr__(self, key: str, value: Any) -> None:
+        if key in type(self).__dict__:
+            return super().__setattr__(key, value)
         # Forward `tp_` attributes from PyTypeObject
         if key.startswith("tp_") and hasattr(self._pyobject, key):
             if not self._unsafe:

--- a/src/einspect/views/view_type.py
+++ b/src/einspect/views/view_type.py
@@ -434,3 +434,23 @@ class TypeView(VarView[_T, None, None]):
             setattr(self._pyobject, key, value)
             return
         super().__setattr__(key, value)
+
+    @property
+    def tp_name(self) -> str:
+        """Return the type's name."""
+        return self._pyobject.tp_name.decode("utf-8")
+
+    @tp_name.setter
+    def tp_name(self, value: str) -> None:
+        """Set the type's name."""
+        self._pyobject.tp_name = value.encode("utf-8")
+
+    @property
+    def tp_flags(self) -> TpFlags:
+        """Return the type's flags."""
+        return TpFlags(self._pyobject.tp_flags)
+
+    @tp_flags.setter
+    def tp_flags(self, value: int | TpFlags) -> None:
+        """Set the type's flags."""
+        self._pyobject.tp_flags = value

--- a/tests/test_impl.py
+++ b/tests/test_impl.py
@@ -5,7 +5,7 @@ from contextlib import ExitStack
 
 import pytest
 
-from einspect import impl, orig, view
+from einspect import NULL, impl, orig, view
 
 
 def test_impl_error():

--- a/tests/test_impl_sp.py
+++ b/tests/test_impl_sp.py
@@ -119,3 +119,19 @@ def test_impl_new():
     obj = Foo(1, 2, kwd="hi")
     assert isinstance(obj, Foo)
     assert _call == (Foo, (1, 2), {"kwd": "hi"})
+
+
+# noinspection PyUnresolvedReferences
+@pytest.mark.run_in_subprocess
+def test_impl_object():
+    @impl(object)
+    def __matmul__(self, other):
+        return self.__class__.__name__ + str(other)
+
+    assert object() @ 1 == "object1"
+    assert int() @ 10 == "int10"
+
+    # Restore original
+    view(object).restore("__matmul__")
+    with pytest.raises(TypeError):
+        _ = object()[3]

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Union
+
+from einspect._typing import is_union
+
+
+def test_is_union():
+    x = Union[int, str]
+    assert is_union(x)
+    assert not is_union(int)

--- a/tests/views/test_move.py
+++ b/tests/views/test_move.py
@@ -94,7 +94,6 @@ def test_swap():
     assert b[0] == "B"
 
 
-@pytest.mark.run_in_subprocess
 def test_swap_dict():
     # Classes with instance dicts should also be swapped
     A = type("A", (int,), {})

--- a/tests/views/test_view_type.py
+++ b/tests/views/test_view_type.py
@@ -23,10 +23,12 @@ class TestTypeView(TestView):
 
     def test_py_obj_attrs(self):
         v = self.view_type(set)
-        assert v.tp_name == b"set"
+        assert v.tp_name == "set"
 
         with v.unsafe():
-            v.tp_name = b"abc"
+            v.tp_name = "set"
+
+        assert v.tp_name == "set"
 
     def test_immutable(self):
         # int type should be immutable


### PR DESCRIPTION
## Adds
- `PyTypeObject.Ready` pythonapi method

## Enhancements
- Improved stability for `impl` and `View.__setitem__` with new PyMethods struct allocation mode

## Fixes
- Fix Struct `__setattr__` cast for ctypes.PYFUNCTION types that would always cast to NULL