### PR TITLE
Fix TypeView.restore sentinel handling with no named args

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
 project = "einspect"
 copyright = "2023, Ionite"
 author = "Ionite"
-release = "v0.5.15"
+release = "v0.5.16"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "einspect"
-version = "0.5.15"
+version = "0.5.16"
 packages = [{ include = "einspect", from = "src" }]
 description = "Extended Inspect - view and modify memory structs of runtime objects."
 authors = ["ionite34 <dev@ionite.io>"]

--- a/src/einspect/__init__.py
+++ b/src/einspect/__init__.py
@@ -8,7 +8,7 @@ from einspect.views.unsafe import global_unsafe
 from einspect.views.view_type import impl
 
 __all__ = ("view", "unsafe", "impl", "orig", "ptr", "NULL", "__version__")
-__version__ = "0.5.15"
+__version__ = "0.5.16"
 
 unsafe = global_unsafe
 

--- a/src/einspect/type_orig.py
+++ b/src/einspect/type_orig.py
@@ -141,6 +141,16 @@ def get_type_cache(type_: type) -> dict[str, Any]:
         ) from None
 
 
+def get_impls(type_: type) -> set[str]:
+    """Get the impls cache for the type."""
+    try:
+        return wk_dict_getitem(_impls, type_)
+    except KeyError:
+        raise KeyError(
+            f"Original attributes cache was not found for type {type_!r}"
+        ) from None
+
+
 def normalize_slot_attr(attr: object | TypeNewWrapper) -> Any:
     """Normalize a slot attribute to its original value."""
     if isinstance(attr, TypeNewWrapper):

--- a/src/einspect/type_orig.py
+++ b/src/einspect/type_orig.py
@@ -66,6 +66,14 @@ def add_impls(type_: type, *attrs: str) -> None:
     attrs_set.update(attrs)
 
 
+def remove_impls(type_: type, *attrs: str) -> None:
+    """Remove a set of implemented attributes from the cache."""
+    attrs_set = wk_dict_getitem(_impls, type_)
+    if attrs_set is not None:
+        for attr in attrs:
+            attrs_set.discard(attr)
+
+
 def try_cache_attr(
     type_: type,
     name: str,

--- a/src/einspect/views/view_type.py
+++ b/src/einspect/views/view_type.py
@@ -28,6 +28,7 @@ from einspect.type_orig import (
     in_cache,
     in_impls,
     normalize_slot_attr,
+    remove_impls,
     try_cache_attr,
 )
 from einspect.views.view_base import REF_DEFAULT, VarView
@@ -359,17 +360,19 @@ class TypeView(VarView[_T, None, None]):
         names = [get_func_name(n) if callable(n) else n for n in names]
         # Check all names exist first
         for name in names:
-            if in_cache(type_, name):
+            if in_impls(type_, name) and in_cache(type_, name):
                 attr = get_cache(type_, name)
                 # MISSING is a special case, it means there is no original attribute
                 if attr is MISSING:
                     # Same as no attribute, delete it
                     del self[name]
+                    remove_impls(type_, name)
                 else:
                     self[name] = normalize_slot_attr(attr)
             # If in impl record, and not in cache, remove the attribute
             elif in_impls(type_, name):
                 del self[name]
+                remove_impls(type_, name)
             else:
                 raise AttributeError(
                     f"{type_.__name__!r} has no original attribute {name!r}"

--- a/src/einspect/views/view_type.py
+++ b/src/einspect/views/view_type.py
@@ -24,7 +24,7 @@ from einspect.type_orig import (
     MISSING,
     add_impls,
     get_cache,
-    get_type_cache,
+    get_impls,
     in_cache,
     in_impls,
     normalize_slot_attr,
@@ -353,8 +353,7 @@ class TypeView(VarView[_T, None, None]):
 
         if not names:
             # Restore all attributes
-            type_cache = get_type_cache(type_)
-            names = type_cache.keys()
+            names = get_impls(type_)
 
         # Normalize names of stuff like properties and class methods
         names = [get_func_name(n) if callable(n) else n for n in names]

--- a/src/einspect/views/view_type.py
+++ b/src/einspect/views/view_type.py
@@ -353,9 +353,7 @@ class TypeView(VarView[_T, None, None]):
         if not names:
             # Restore all attributes
             type_cache = get_type_cache(type_)
-            for name, attr in type_cache.items():
-                self[name] = normalize_slot_attr(attr)
-            return type_
+            names = type_cache.keys()
 
         # Normalize names of stuff like properties and class methods
         names = [get_func_name(n) if callable(n) else n for n in names]

--- a/tests/test_impl_sp.py
+++ b/tests/test_impl_sp.py
@@ -6,6 +6,30 @@ import pytest
 from einspect import impl, orig, view
 
 
+@pytest.mark.order(1)
+@pytest.mark.run_in_subprocess
+def test_impl_restore():
+    @impl(int)
+    def __repr__(self):
+        return "repr"
+
+    @impl(int)
+    def x(self):
+        return "x"
+
+    n = 5
+    assert repr(n) == "repr"
+    # noinspection PyUnresolvedReferences
+    assert n.x() == "x"
+
+    view(int).restore()
+
+    assert repr(n) == "5"
+    with pytest.raises(AttributeError):
+        # noinspection PyUnresolvedReferences
+        _ = n.x()
+
+
 @pytest.mark.run_in_subprocess
 def test_impl_new_func_finalize():
     # Test that finalizer works, deleting function should remove the impl
@@ -135,26 +159,3 @@ def test_impl_object():
     view(object).restore("__matmul__")
     with pytest.raises(TypeError):
         _ = object()[3]
-
-
-@pytest.mark.run_in_subprocess
-def test_impl_restore():
-    @impl(int)
-    def __repr__(self):
-        return "repr"
-
-    @impl(int)
-    def x(self):
-        return "x"
-
-    n = 5
-    assert repr(n) == "repr"
-    # noinspection PyUnresolvedReferences
-    assert n.x() == "x"
-
-    view(int).restore()
-
-    assert repr(n) == "5"
-    with pytest.raises(AttributeError):
-        # noinspection PyUnresolvedReferences
-        _ = n.x()

--- a/tests/test_impl_sp.py
+++ b/tests/test_impl_sp.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 import pytest
 
 from einspect import impl, orig, view
+from einspect.type_orig import _impls
 
 
 @pytest.mark.run_in_subprocess
 def test_impl_restore():
+    # Clear impls cache
+    backup_impls = _impls.copy()
+    _impls.clear()
+
     @impl(int)
     def __repr__(self):
         return "repr"
@@ -27,6 +32,10 @@ def test_impl_restore():
     with pytest.raises(AttributeError):
         # noinspection PyUnresolvedReferences
         _ = n.x()
+
+    # Restore impls cache
+    _impls.clear()
+    _impls.update(backup_impls)
 
 
 @pytest.mark.run_in_subprocess

--- a/tests/test_impl_sp.py
+++ b/tests/test_impl_sp.py
@@ -6,7 +6,6 @@ import pytest
 from einspect import impl, orig, view
 
 
-@pytest.mark.order(1)
 @pytest.mark.run_in_subprocess
 def test_impl_restore():
     @impl(int)

--- a/tests/test_impl_sp.py
+++ b/tests/test_impl_sp.py
@@ -135,3 +135,26 @@ def test_impl_object():
     view(object).restore("__matmul__")
     with pytest.raises(TypeError):
         _ = object()[3]
+
+
+@pytest.mark.run_in_subprocess
+def test_impl_restore():
+    @impl(int)
+    def __repr__(self):
+        return "repr"
+
+    @impl(int)
+    def x(self):
+        return "x"
+
+    n = 5
+    assert repr(n) == "repr"
+    # noinspection PyUnresolvedReferences
+    assert n.x() == "x"
+
+    view(int).restore()
+
+    assert repr(n) == "5"
+    with pytest.raises(AttributeError):
+        # noinspection PyUnresolvedReferences
+        _ = n.x()


### PR DESCRIPTION
- Fixes bug where TypeView.restore would incorrectly set the `MISSING` sentinel as the restored value when no named attributes were provided.